### PR TITLE
Battery protection (#888)

### DIFF
--- a/selfdrive/controls/lib/alerts_offroad.json
+++ b/selfdrive/controls/lib/alerts_offroad.json
@@ -1,6 +1,6 @@
 {
   "Offroad_ChargeDisabled": {
-    "text": "EON charging disabled after car being off for more than 3 days. Turn ignition on to start charging again.",
+    "text": "EON charging disabled after car being off for more than 3 days or car voltage too low. Turn ignition on to start charging again.",
     "severity": 0
   },
   "Offroad_TemperatureTooHigh": {


### PR DESCRIPTION
* Battery protection

If your car battery voltage is lower than 0% switch off charging to stop the Eon from damaging the 12v car battery. Leaving you with a car that can not start but has a fully charged eon ;-)

* add rbiasini comment && !ignition

* Update Offroad_ChargeDisabled with voltage low

* simplify alert

* non-temporal hysteresis from @rbiasini

And up the start charge limit to 12v. i.e. 50% car battery voltage

* once battery power recovers to 11.500 volts charge

This leaves 1v inbetween for any fluctuations that could occur.

* fix indent

* Fix indent of whole block

It looks like sometimes when you copy and paste into the github web interface some white spacing gets added or removed. BE AWARE!

Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
