### PR TITLE
Return type default if type of data in op_params.json doesn't match a…

### DIFF
--- a/common/op_params.py
+++ b/common/op_params.py
@@ -134,7 +134,29 @@ class opParams:
     self.update_params(key, force_update)
     if key is None:
       return self.params
-    return self.params[key] if key in self.params else default
+
+    if key in self.params:
+      if key in self.default_params and 'allowed_types' in self.default_params[key]:
+        value = self.params[key]
+        allowed_types = self.default_params[key]['allowed_types']
+        valid_type = type(value) in allowed_types
+        if not valid_type:
+          value = self.value_from_types(allowed_types)
+      else:
+        value = self.params[key]
+    else:
+      value = default
+
+    return value
+
+  def value_from_types(self, allowed_types):
+    if list in allowed_types:
+      return []
+    elif float in allowed_types or int in allowed_types:
+      return 0
+    elif str in allowed_types:
+      return ''
+    return None
 
   def update_params(self, key, force_update):
     if force_update or (key in self.default_params and 'live' in self.default_params[key] and self.default_params[key]['live']):  # if is a live param, we want to get updates while openpilot is running


### PR DESCRIPTION
…llowed types to avoid fork errors where we might return an incorrect value type