### PR TITLE
Power monitoring fix (#1269)

### DIFF
--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -187,7 +187,7 @@ def thermald_thread():
     handle_fan = handle_fan_eon
 
   params = Params()
-  pm = PowerMonitoring()
+  pm = PowerMonitoring(is_uno)
 
   while 1:
     health = messaging.recv_sock(health_sock, wait=True)


### PR DESCRIPTION
* Release lock after exceptions

* No pulsed measurement on uno

* Fix last_measurement_time=None while integrating when going offroad

* Also clear next pulsed measurement time

* Move around locks

* Locks are good now?

Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
