### PR TITLE
Add a toggle to enable model long

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -2014,6 +2014,10 @@ struct DynamicCameraOffset {
   keepingRight @1 :Bool;
 }
 
+struct ModelLongButton {
+  enabled @0 :Bool;
+}
+
 struct Event {
   # in nanoseconds?
   logMonoTime @0 :UInt64;
@@ -2098,5 +2102,6 @@ struct Event {
     laneSpeed @76 :LaneSpeed;
     laneSpeedButton @77 :LaneSpeedButton;
     dynamicCameraOffset @78 :DynamicCameraOffset;
+    modelLongButton @79 :ModelLongButton;
   }
 }

--- a/cereal/service_list.yaml
+++ b/cereal/service_list.yaml
@@ -83,6 +83,7 @@ dynamicFollowButton: [8076, false, 0.]
 laneSpeed: [8077, false, 0.]
 laneSpeedButton: [8078, false, 0.]
 dynamicCameraOffset: [8079, false, 0.]
+modelLongButton: [8080, false, 0.]
 
 testModel: [8040, false, 0.]
 testLiveLocation: [8045, false, 0.]

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -814,8 +814,8 @@ void ui_draw(UIState *s) {
   glViewport(0, 0, s->fb_w, s->fb_h);
   nvgBeginFrame(s->vg, s->fb_w, s->fb_h, 1.0f);
   ui_draw_sidebar(s);
+  s->status = STATUS_DISENGAGED;
   if (s->started && s->active_app == cereal::UiLayoutState::App::NONE && s->status != STATUS_STOPPED && s->vision_seen) {
-    printf("drawing\n");
     ui_draw_vision(s);
   } else{
     printf("NOT drawing\n");

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -814,9 +814,9 @@ void ui_draw(UIState *s) {
   glViewport(0, 0, s->fb_w, s->fb_h);
   nvgBeginFrame(s->vg, s->fb_w, s->fb_h, 1.0f);
   ui_draw_sidebar(s);
-  printf("%s\n", s->vision_seen);
-  printf("%s\n", s->started);
-  printf("%s\n", s->active_app);
+  printf("%d\n", s->vision_seen);
+  printf("%d\n", s->started);
+  printf("%hu\n", s->active_app);
   if (s->started && s->active_app == cereal::UiLayoutState::App::NONE && s->status != STATUS_STOPPED && s->vision_seen) {
     ui_draw_vision(s);
   } else{

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -658,6 +658,32 @@ static void ui_draw_df_button(UIState *s) {
   nvgText(s->vg, btn_x - 34, btn_y + 50 + 15, "profile", NULL);
 }
 
+static void ui_draw_ml_button(UIState *s) {
+  int test_button = nvgCreateImage(s->vg, "../assets/images/button_settings.png", 1);
+
+  int btn_w = 150;
+  int btn_h = 150;
+  int btn_x = 1920 - btn_w - 200;  // 150 + 50 padding
+  int btn_y = 1080 - btn_h - 50;
+
+  ui_draw_image(s->vg, btn_x, btn_y, btn_w, btn_h, test_button, 1.0f);
+
+
+//  nvgBeginPath(s->vg);
+//  nvgRoundedRect(s->vg, btn_x-110, btn_y-45, btn_w, btn_h, 100);
+//  nvgStrokeColor(s->vg, nvgRGBA(12, 79, 130, 255));
+//  nvgStrokeWidth(s->vg, 11);
+//  nvgStroke(s->vg);
+//
+//  nvgFillColor(s->vg, nvgRGBA(255, 255, 255, 255));
+//  nvgFontSize(s->vg, 80);
+//  nvgText(s->vg, btn_x - 38, btn_y + 30, "LS", NULL);
+//
+//  nvgFillColor(s->vg, nvgRGBA(255, 255, 255, 255));
+//  nvgFontSize(s->vg, 45);
+//  nvgText(s->vg, btn_x - 34, btn_y + 50 + 15, "mode", NULL);
+}
+
 static void ui_draw_vision_header(UIState *s) {
   const UIScene *scene = &s->scene;
   int ui_viz_rx = scene->ui_viz_rx;
@@ -685,6 +711,7 @@ static void ui_draw_vision_footer(UIState *s) {
   ui_draw_vision_face(s);
   ui_draw_df_button(s);
   ui_draw_ls_button(s);
+  ui_draw_ml_button(s);
 
 #ifdef SHOW_SPEEDLIMIT
   // ui_draw_vision_map(s);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -815,7 +815,10 @@ void ui_draw(UIState *s) {
   nvgBeginFrame(s->vg, s->fb_w, s->fb_h, 1.0f);
   ui_draw_sidebar(s);
   if (s->started && s->active_app == cereal::UiLayoutState::App::NONE && s->status != STATUS_STOPPED && s->vision_seen) {
+    printf("drawing\n");
     ui_draw_vision(s);
+  } else{
+    printf("NOT drawing\n");
   }
   nvgEndFrame(s->vg);
   glDisable(GL_BLEND);

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -814,7 +814,9 @@ void ui_draw(UIState *s) {
   glViewport(0, 0, s->fb_w, s->fb_h);
   nvgBeginFrame(s->vg, s->fb_w, s->fb_h, 1.0f);
   ui_draw_sidebar(s);
-  s->status = STATUS_DISENGAGED;
+  printf("%s\n", s->vision_seen);
+  printf("%s\n", s->started);
+  printf("%s\n", s->active_app);
   if (s->started && s->active_app == cereal::UiLayoutState::App::NONE && s->status != STATUS_STOPPED && s->vision_seen) {
     ui_draw_vision(s);
   } else{

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -814,9 +814,9 @@ void ui_draw(UIState *s) {
   glViewport(0, 0, s->fb_w, s->fb_h);
   nvgBeginFrame(s->vg, s->fb_w, s->fb_h, 1.0f);
   ui_draw_sidebar(s);
-  printf("%d\n", s->vision_seen);
-  printf("%d\n", s->started);
-  printf("%hu\n", s->active_app);
+  s->vision_seen = true;
+  s->started = true;
+  s->active_app = cereal::UiLayoutState::App::NONE;
   if (s->started && s->active_app == cereal::UiLayoutState::App::NONE && s->status != STATUS_STOPPED && s->vision_seen) {
     ui_draw_vision(s);
   } else{

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -811,6 +811,7 @@ int main(int argc, char* argv[]) {
   while (!do_exit) {
     bool should_swap = false;
     s->started = true;
+    s->status = STATUS_DISENGAGED;
     if (!s->started) {
       printf("delay\n");
       // Delay a while to avoid 9% cpu usage while car is not started and user is keeping touching on the screen.

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -844,8 +844,6 @@ int main(int argc, char* argv[]) {
       if (!handle_df_touch(s, touch_x, touch_y) && !handle_ls_touch(s, touch_x, touch_y)) {  // disables sidebar from popping out when tapping df or ls button
         handle_vision_touch(s, touch_x, touch_y);
       }
-    } else {
-      printf("not touched\n");
     }
 
     if (!s->started) {
@@ -859,7 +857,10 @@ int main(int argc, char* argv[]) {
       set_awake(s, true);
       // Car started, fetch a new rgb image from ipc
       if (s->vision_connected){
+        printf("vision connected\n");
         ui_update(s);
+      } else {
+        printf("vision not connected\n");
       }
 
       check_messages(s);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -227,7 +227,7 @@ static void ui_init(UIState *s) {
                                     , "liveMapData"
 #endif
   });
-  s->pm = new PubMaster({"offroadLayout", "laneSpeedButton", "dynamicFollowButton"});
+  s->pm = new PubMaster({"offroadLayout", "laneSpeedButton", "dynamicFollowButton", "modelLongButton"});
 
   s->ipc_fd = -1;
   s->scene.satelliteCount = -1;
@@ -271,7 +271,7 @@ static void ui_init_vision(UIState *s, const VisionStreamBufs back_bufs,
 
   s->scene.dfButtonStatus = 0;
   s->scene.lsButtonStatus = 0;
-
+  s->scene.mlButtonStatus = 0;
 
   s->rgb_width = back_bufs.width;
   s->rgb_height = back_bufs.height;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -859,8 +859,6 @@ int main(int argc, char* argv[]) {
       if (s->vision_connected){
         printf("vision connected\n");
         ui_update(s);
-      } else {
-        printf("vision not connected\n");
       }
 
       check_messages(s);
@@ -890,9 +888,12 @@ int main(int argc, char* argv[]) {
 
     // Don't waste resources on drawing in case screen is off
     if (s->awake) {
+      printf("drawing with paint.cc!\n")
       ui_draw(s);
       glFinish();
       should_swap = true;
+    } else {
+      printf("not drawing with paint.cc\n");
     }
 
     s->sound.setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5)); // up one notch every 5 m/s

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -890,7 +890,7 @@ int main(int argc, char* argv[]) {
     }
 
     s->sound.setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5)); // up one notch every 5 m/s
-    !s->controls_seen = true;
+    s->controls_seen = true;
 
     if (s->controls_timeout > 0) {
       s->controls_timeout--;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -837,12 +837,15 @@ int main(int argc, char* argv[]) {
     int touch_x = -1, touch_y = -1;
     int touched = touch_poll(&touch, &touch_x, &touch_y, 0);
     if (touched == 1) {
+      printf("touched\n");
       set_awake(s, true);
       handle_sidebar_touch(s, touch_x, touch_y);
 
       if (!handle_df_touch(s, touch_x, touch_y) && !handle_ls_touch(s, touch_x, touch_y)) {  // disables sidebar from popping out when tapping df or ls button
         handle_vision_touch(s, touch_x, touch_y);
       }
+    } else {
+      printf("not touched\n");
     }
 
     if (!s->started) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -811,6 +811,7 @@ int main(int argc, char* argv[]) {
   while (!do_exit) {
     bool should_swap = false;
     if (!s->started) {
+    printf("here\n");
       // Delay a while to avoid 9% cpu usage while car is not started and user is keeping touching on the screen.
       // Don't hold the lock while sleeping, so that vision_connect_thread have chances to get the lock.
       usleep(30 * 1000);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -891,7 +891,7 @@ int main(int argc, char* argv[]) {
 
     s->sound.setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5)); // up one notch every 5 m/s
     s->controls_seen = true;
-
+    s->controls_timeout = 20;
     if (s->controls_timeout > 0) {
       s->controls_timeout--;
     } else if (s->started) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -442,7 +442,8 @@ void handle_message(UIState *s, SubMaster &sm) {
     s->preview_started = data.getIsPreview();
   }
 
-  s->started = scene.thermal.getStarted() || s->preview_started;
+//  s->started = scene.thermal.getStarted() || s->preview_started;
+  s->started = true;
   // Handle onroad/offroad transition
   if (!s->started) {
     if (s->status != STATUS_STOPPED) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -888,7 +888,7 @@ int main(int argc, char* argv[]) {
 
     // Don't waste resources on drawing in case screen is off
     if (s->awake) {
-      printf("drawing with paint.cc!\n")
+      printf("drawing with paint.cc!\n");
       ui_draw(s);
       glFinish();
       should_swap = true;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -890,6 +890,7 @@ int main(int argc, char* argv[]) {
     }
 
     s->sound.setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5)); // up one notch every 5 m/s
+    !s->controls_seen = true;
 
     if (s->controls_timeout > 0) {
       s->controls_timeout--;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -810,8 +810,9 @@ int main(int argc, char* argv[]) {
 
   while (!do_exit) {
     bool should_swap = false;
+    s->started = true;
     if (!s->started) {
-    printf("here\n");
+      printf("delay\n");
       // Delay a while to avoid 9% cpu usage while car is not started and user is keeping touching on the screen.
       // Don't hold the lock while sleeping, so that vision_connect_thread have chances to get the lock.
       usleep(30 * 1000);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -888,12 +888,11 @@ int main(int argc, char* argv[]) {
 
     // Don't waste resources on drawing in case screen is off
     if (s->awake) {
-      printf("drawing with paint.cc!\n");
       ui_draw(s);
       glFinish();
       should_swap = true;
     } else {
-      printf("not drawing with paint.cc\n");
+      printf("NOT drawing with paint.cc\n");
     }
 
     s->sound.setVolume(fmin(MAX_VOLUME, MIN_VOLUME + s->scene.controls_state.getVEgo() / 5)); // up one notch every 5 m/s

--- a/selfdrive/ui/ui.hpp
+++ b/selfdrive/ui/ui.hpp
@@ -126,6 +126,7 @@ typedef struct UIScene {
 
   int dfButtonStatus;
   int lsButtonStatus;
+  int mlButtonStatus;
 
   cereal::HealthData::HwType hwType;
   int satelliteCount;


### PR DESCRIPTION
Not nearly done yet. If/when this gets merged the standard MPCs will ALWAYS be included to not allow the model to travel faster than safe speeds. (so the model will only be used for slowing down, not accelerating)