### PR TITLE
opParams refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Here are the main parameters you can change with this fork:
 - **Experimental params**:
   - `support_white_panda`: This allows users with the original white panda to use openpilot above 0.7.7. The high precision localizer's performance may be reduced due to a lack of GPS
   - `prius_use_lqr`: If you have a newer Prius with a good angle sensor, you can try enabling this to use LQR
+  - `corolla_use_lqr`: Enable this to use LQR for lat with your Corolla (2017) *(can be enabled for all years by request)*
 
 A full list of parameters that you can modify are [located here](common/op_params.py#L40).
 

--- a/common/colors.py
+++ b/common/colors.py
@@ -4,6 +4,7 @@ class COLORS:
     self.OKBLUE = '\033[94m'
     self.CBLUE = '\33[44m'
     self.BOLD = '\033[1m'
+    self.CITALIC = '\33[3m'
     self.OKGREEN = '\033[92m'
     self.CWHITE = '\33[37m'
     self.ENDC = '\033[0m' + self.CWHITE

--- a/common/colors.py
+++ b/common/colors.py
@@ -28,6 +28,9 @@ class COLORS:
   def BASE(self, col):  # seems to support more colors
     return '\33[38;5;{}m'.format(col)
 
+  def BASEBG(self, col):  # seems to support more colors
+    return '\33[48;5;{}m'.format(col)
+
 
 COLORS = COLORS()
 

--- a/common/colors.py
+++ b/common/colors.py
@@ -1,5 +1,6 @@
 class COLORS:
-  BASE = '\33[38;5;{}m'  # seems to support more colors
+  def BASE(col):  # seems to support more colors
+    return '\33[38;5;{}m'.format(col)
   HEADER = '\033[95m'
   OKBLUE = '\033[94m'
   CBLUE = '\33[44m'

--- a/common/colors.py
+++ b/common/colors.py
@@ -20,7 +20,8 @@ class COLORS:
   INFO = PURPLE_BG
   SUCCESS = OKGREEN
   PROMPT = YELLOW
-  CYAN = '\033[36m'
+  DBLUE = '\033[36m'
+  CYAN = BASE.format(45)
   WARNING = '\033[33m'
 
 def opParams_warning(msg):

--- a/common/colors.py
+++ b/common/colors.py
@@ -21,7 +21,7 @@ class COLORS:
   SUCCESS = OKGREEN
   PROMPT = YELLOW
   DBLUE = '\033[36m'
-  CYAN = BASE.format(45)
+  CYAN = BASE.format(39)
   WARNING = '\033[33m'
 
 def opParams_warning(msg):

--- a/common/colors.py
+++ b/common/colors.py
@@ -1,6 +1,7 @@
 class COLORS:
-  def BASE(col):  # seems to support more colors
+  def BASE(self, col):  # seems to support more colors
     return '\33[38;5;{}m'.format(col)
+
   HEADER = '\033[95m'
   OKBLUE = '\033[94m'
   CBLUE = '\33[44m'
@@ -10,23 +11,28 @@ class COLORS:
   ENDC = '\033[0m' + CWHITE
   UNDERLINE = '\033[4m'
   PINK = '\33[38;5;207m'
-  PRETTY_YELLOW = BASE.format(220)
+  PRETTY_YELLOW = BASE(220)
 
   RED = '\033[91m'
   PURPLE_BG = '\33[45m'
   YELLOW = '\033[93m'
-  BLUE_GREEN = BASE.format(85)
+  BLUE_GREEN = BASE(85)
 
   FAIL = RED
   INFO = PURPLE_BG
   SUCCESS = OKGREEN
   PROMPT = YELLOW
   DBLUE = '\033[36m'
-  CYAN = BASE.format(39)
+  CYAN = BASE(39)
   WARNING = '\033[33m'
+
+
+COLORS = COLORS()
+
 
 def opParams_warning(msg):
   print('{}opParams WARNING: {}{}'.format(COLORS.WARNING, msg, COLORS.ENDC))
+
 
 def opParams_error(msg):
   print('{}opParams ERROR: {}{}'.format(COLORS.FAIL, msg, COLORS.ENDC))

--- a/common/colors.py
+++ b/common/colors.py
@@ -1,30 +1,31 @@
 class COLORS:
+  def __init__(self):
+    self.HEADER = '\033[95m'
+    self.OKBLUE = '\033[94m'
+    self.CBLUE = '\33[44m'
+    self.BOLD = '\033[1m'
+    self.OKGREEN = '\033[92m'
+    self.CWHITE = '\33[37m'
+    self.ENDC = '\033[0m' + self.CWHITE
+    self.UNDERLINE = '\033[4m'
+    self.PINK = '\33[38;5;207m'
+    self.PRETTY_YELLOW = self.BASE(220)
+
+    self.RED = '\033[91m'
+    self.PURPLE_BG = '\33[45m'
+    self.YELLOW = '\033[93m'
+    self.BLUE_GREEN = self.BASE(85)
+
+    self.FAIL = self.RED
+    self.INFO = self.PURPLE_BG
+    self.SUCCESS = self.OKGREEN
+    self.PROMPT = self.YELLOW
+    self.DBLUE = '\033[36m'
+    self.CYAN = self.BASE(39)
+    self.WARNING = '\033[33m'
+
   def BASE(self, col):  # seems to support more colors
     return '\33[38;5;{}m'.format(col)
-
-  HEADER = '\033[95m'
-  OKBLUE = '\033[94m'
-  CBLUE = '\33[44m'
-  BOLD = '\033[1m'
-  OKGREEN = '\033[92m'
-  CWHITE = '\33[37m'
-  ENDC = '\033[0m' + CWHITE
-  UNDERLINE = '\033[4m'
-  PINK = '\33[38;5;207m'
-  PRETTY_YELLOW = BASE(220)
-
-  RED = '\033[91m'
-  PURPLE_BG = '\33[45m'
-  YELLOW = '\033[93m'
-  BLUE_GREEN = BASE(85)
-
-  FAIL = RED
-  INFO = PURPLE_BG
-  SUCCESS = OKGREEN
-  PROMPT = YELLOW
-  DBLUE = '\033[36m'
-  CYAN = BASE(39)
-  WARNING = '\033[33m'
 
 
 COLORS = COLORS()

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -27,8 +27,7 @@ class Param:
     self.allowed_types = allowed_types
     self.description = description
     self.hidden = hidden
-    self.live = False
-    self.is_list = False
+    self.live, self.is_list = False, False
     self._create_attrs()
 
   def is_valid(self, value):

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -109,7 +109,7 @@ class opParams:
     self._run_init()  # restores, reads, and updates params
 
   def _run_init(self):  # does first time initializing of default params
-    self.params = {key: value.default for key, value in self.fork_params.items()}  # in case file is corrupted
+    self.params = self._get_all_params(default=True)  # in case file is corrupted
     if travis:
       return
 
@@ -129,7 +129,7 @@ class opParams:
 
   def get(self, key=None, force_live=False):  # any params you try to get MUST be in fork_params
     if key is None:
-      return self._get_all()
+      return self._get_all_params()
     self._check_key_exists(key, 'get')
 
     param_info = self.param_info(key)
@@ -183,8 +183,10 @@ class opParams:
         deleted = True
     return deleted
 
-  def _get_all(self):  # returns all non-hidden params
-    return {k: v for k, v in self.params.items() if k in self.fork_params and not self.param_info(k).hidden}
+  def _get_all_params(self, default=False):
+    if not default:
+      return {k: v for k, v in self.params.items() if k in self.fork_params}
+    return {k: p.default for k, p in self.fork_params.items()}
 
   def _update_params(self, param_info, force_live):
     if param_info.live or force_live:  # if is a live param, we want to get updates while openpilot is running

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import json
-from selfdrive.crash import client
 from common.colors import opParams_error as error
 from common.colors import opParams_warning as warning
 try:
@@ -140,7 +139,6 @@ class opParams:
       return value  # all good, returning user's value
 
     warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
-    client.captureMessage("User's param: {} is not of valid type! (value: {} type: {})".format(key, value, type(value)), level='info')
     return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -185,7 +185,7 @@ class opParams:
   def _get_all_params(self, default=False, return_hidden=False):
     if default:
       return {k: p.default for k, p in self.fork_params.items()}
-    return {k: self.params[k] for k, p in self.fork_params.items() if not p.hidden or return_hidden}
+    return {k: self.params[k] for k, p in self.fork_params.items() if k in self.params and (not p.hidden or return_hidden)}
 
   def _update_params(self, param_info, force_live):
     if force_live or param_info.live:  # if is a live param, we want to get updates while openpilot is running

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -28,8 +28,14 @@ class Param:
     self.description = description
     self.hidden = hidden
     self.live, self.is_list = False, False
+    self._create_attrs()
 
-    # Create attributes and check Param is valid
+  def is_valid(self, value):
+    if not self.has_allowed_types:
+      return True
+    return type(value) in self.allowed_types
+
+  def _create_attrs(self):  # Create attributes and check Param is valid
     self.has_allowed_types = isinstance(self.allowed_types, list) and len(self.allowed_types) > 0
     self.has_description = self.description is not None
     if self.has_allowed_types:
@@ -37,11 +43,6 @@ class Param:
     self.is_list = list in self.allowed_types
     if self.is_list:
       self.allowed_types.remove(list)
-
-  def is_valid(self, value):
-    if not self.has_allowed_types:
-      return True
-    return type(value) in self.allowed_types
 
 
 class opParams:

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -28,14 +28,8 @@ class Param:
     self.description = description
     self.hidden = hidden
     self.live, self.is_list = False, False
-    self._create_attrs()
 
-  def is_valid(self, value):
-    if not self.has_allowed_types:
-      return True
-    return type(value) in self.allowed_types
-
-  def _create_attrs(self):
+    # Create attributes and check Param is valid
     self.has_allowed_types = isinstance(self.allowed_types, list) and len(self.allowed_types) > 0
     self.has_description = self.description is not None
     if self.has_allowed_types:
@@ -43,6 +37,11 @@ class Param:
     self.is_list = list in self.allowed_types
     if self.is_list:
       self.allowed_types.remove(list)
+
+  def is_valid(self, value):
+    if not self.has_allowed_types:
+      return True
+    return type(value) in self.allowed_types
 
 
 class opParams:

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -91,6 +91,7 @@ class opParams:
                         'support_white_panda': Param(False, bool, 'Enable this to allow engagement with the deprecated white panda.\n'
                                                                   'localizer might not work correctly'),
                         'prius_use_lqr': Param(False, bool, 'If you have a newer Prius with a good angle sensor, you can try enabling this to use LQR'),
+                        'corolla_use_lqr': Param(False, bool, 'Enable this to use LQR for lat with your Corolla (2017)'),
                         'username': Param(None, [type(None), str, bool], 'Your identifier provided with any crash logs sent to Sentry.\n'
                                                                          'Helps the developer reach out to you if anything goes wrong'),
 

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -140,7 +140,7 @@ class opParams:
       return value  # all good, returning user's value
 
     warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
-    client.captureMessage("User's param: {} is not of valid type! (value: {})".format(key, value), level='info')
+    client.captureMessage("User's param: {} is not of valid type! (value: {} type: {})".format(key, value, type(value)), level='info')
     return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -20,7 +20,7 @@ class ValueTypes:
 
 
 class Param:
-  def __init__(self, default=None, allowed_types=None, description=None, hidden=False):
+  def __init__(self, default=None, allowed_types=[], description=None, hidden=False):
     self.default = default
     if not isinstance(allowed_types, list):
       allowed_types = [allowed_types]

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -47,6 +47,20 @@ class Param:
 
 class opParams:
   def __init__(self):
+    """
+      To add your own parameter to opParams in your fork, simply add a new entry in self.fork_params, instancing a new Param class with at minimum a default value.
+      The allowed_types and description args are not required but highly recommended to help users edit their parameters with opEdit safely.
+        - The description value will be shown to users when they use opEdit to change the value of the parameter.
+        - The allowed_types arg is used to restrict what kinds of values can be entered with opEdit so that users can't crash openpilot with unintended behavior.
+              (setting a param intended to be a number with a boolean, or viceversa for example)
+          Limiting the range of floats or integers is still recommended when `.get`ting the parameter.
+          When a None value is allowed, use `type(None)` instead of None, as opEdit checks the type against the values in the arg with `isinstance()`.
+        - Finally, the live arg tells both opParams and opEdit that it's a live parameter that will change. Therefore, you must place the `op_params.get()` call in the update function so that it can update.
+
+      Here's an example of a good fork_param entry:
+      self.fork_params = {'camera_offset': Param(default=0.06, allowed_types=VT.number)}  # VT.number allows both floats and ints
+    """
+
     VT = ValueTypes()
     self.fork_params = {'camera_offset': Param(0.06, VT.number, 'Your camera offset to use in lane_planner.py'),
                         'dynamic_follow': Param('auto', str, 'Can be: (\'traffic\', \'relaxed\', \'roadtrip\'): Left to right increases in following distance.\n'

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -87,7 +87,7 @@ class opParams:
                         'log_auto_df': Param(False, bool, 'Logs dynamic follow data for auto-df'),
                         'dynamic_camera_offset': Param(True, bool, 'Whether to automatically keep away from oncoming traffic.\n'
                                                                    'Works from 35 to ~60 mph (requires radar)'),
-                        'dynamic_camera_offset_time': Param(2.5, VT.number, 'How long to keep away from oncoming traffic in seconds after losing lead'),
+                        'dynamic_camera_offset_time': Param(3.5, VT.number, 'How long to keep away from oncoming traffic in seconds after losing lead'),
                         'support_white_panda': Param(False, bool, 'Enable this to allow engagement with the deprecated white panda.\n'
                                                                   'localizer might not work correctly'),
                         'prius_use_lqr': Param(False, bool, 'If you have a newer Prius with a good angle sensor, you can try enabling this to use LQR'),

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -109,7 +109,7 @@ class opParams:
     self._run_init()  # restores, reads, and updates params
 
   def _run_init(self):  # does first time initializing of default params
-    self.params = self._format_default_params()  # in case file is corrupted
+    self.params = {key: value.default for key, value in self.fork_params.items()}  # in case file is corrupted
     if travis:
       return
 
@@ -174,9 +174,6 @@ class opParams:
         self.params[key] = param.default
         added = True
     return added
-
-  def _format_default_params(self):
-    return {key: value.default for key, value in self.fork_params.items()}
 
   def _delete_old(self):
     deleted = False

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -182,10 +182,10 @@ class opParams:
         deleted = True
     return deleted
 
-  def _get_all_params(self, default=False):
-    if not default:
-      return {k: v for k, v in self.params.items() if k in self.fork_params}
-    return {k: p.default for k, p in self.fork_params.items()}
+  def _get_all_params(self, default=False, return_hidden=False):
+    if default:
+      return {k: p.default for k, p in self.fork_params.items()}
+    return {k: self.params[k] for k, p in self.fork_params.items() if not p.hidden or return_hidden}
 
   def _update_params(self, param_info, force_live):
     if force_live or param_info.live:  # if is a live param, we want to get updates while openpilot is running

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -190,17 +190,6 @@ class opParams:
   def _get_all(self):  # returns all non-hidden params
     return {k: v for k, v in self.params.items() if k in self.fork_params and not self.param_info(k).hidden}
 
-  def _value_from_types(self, allowed_types):
-    if list in allowed_types:
-      return []
-    elif float in allowed_types or int in allowed_types:
-      return 0
-    elif type(None) in allowed_types:
-      return None
-    elif str in allowed_types:
-      return ''
-    return None  # unknown type
-
   def _update_params(self, param_info, force_live):
     if param_info.live or force_live:  # if is a live param, we want to get updates while openpilot is running
       if not travis and sec_since_boot() - self._last_read_time >= self.read_frequency:  # make sure we aren't reading file too often

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import os
 import json
-from common.colors import opParams_warning as warning
+from selfdrive.crash import client
 from common.colors import opParams_error as error
+from common.colors import opParams_warning as warning
 try:
   from common.realtime import sec_since_boot
 except ImportError:
@@ -139,6 +140,7 @@ class opParams:
       return value  # all good, returning user's value
 
     warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
+    client.captureMessage("User's param: {} is not of valid type! (value: {})".format(key, value), level='info')
     return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -105,7 +105,7 @@ class opParams:
     self._params_file = "/data/op_params.json"
     self._last_read_time = sec_since_boot()
     self.read_frequency = 2.5  # max frequency to read with self.get(...) (sec)
-    self._to_delete = ['reset_integral', 'dyn_camera_offset_i', 'dyn_camera_offset_p', 'lane_hug_direction', 'lane_hug_angle_offset']  # a list of params you want to delete (unused)
+    self._to_delete = ['lane_hug_direction', 'lane_hug_angle_offset']  # a list of params you want to delete (unused)
     self._run_init()  # restores, reads, and updates params
 
   def _run_init(self):  # does first time initializing of default params

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -138,7 +138,7 @@ class opParams:
     if param_info.is_valid(value):  # always valid if no allowed types, otherwise checks to make sure
       return value  # all good, returning user's value
 
-    warning('User\'s value is not valid!')  # somehow... it should always be valid
+    warning('User\'s value type is not valid!')  # somehow... it should always be valid
     return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -128,12 +128,13 @@ class opParams:
       os.chmod(self._params_file, 0o764)
 
   def get(self, key=None, force_live=False):  # any params you try to get MUST be in fork_params
-    if key is None:
-      return self._get_all_params()
-    self._check_key_exists(key, 'get')
-
     param_info = self.param_info(key)
     self._update_params(param_info, force_live)
+
+    if key is None:
+      return self._get_all_params()
+
+    self._check_key_exists(key, 'get')
     value = self.params[key]
     if param_info.is_valid(value):  # always valid if no allowed types, otherwise checks to make sure
       return value  # all good, returning user's value
@@ -189,7 +190,7 @@ class opParams:
     return {k: p.default for k, p in self.fork_params.items()}
 
   def _update_params(self, param_info, force_live):
-    if param_info.live or force_live:  # if is a live param, we want to get updates while openpilot is running
+    if force_live or param_info.live:  # if is a live param, we want to get updates while openpilot is running
       if not travis and sec_since_boot() - self._last_read_time >= self.read_frequency:  # make sure we aren't reading file too often
         if self._read():
           self._last_read_time = sec_since_boot()

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -52,11 +52,11 @@ class opParams:
                         'dynamic_follow': Param('auto', str, 'Can be: (\'traffic\', \'relaxed\', \'roadtrip\'): Left to right increases in following distance.\n'
                                                              'All profiles support dynamic follow so you\'ll get your preferred distance while\n'
                                                              'retaining the smoothness and safety of dynamic follow!'),
-                        'global_df_mod': Param(None, VT.none_or_number, 'The multiplier for the current distance used by dynamic follow. The range is limited from 0.85 to 1.2\n'
-                                                                        'Smaller values will get you closer, larger will get you farther\n'
-                                                                        'This is multiplied by any profile that\'s active. Set to None to disable'),
-                        'min_TR': Param(None, VT.none_or_number, 'The minimum allowed following distance in seconds. Default is 0.9 seconds.\n'
-                                                                 'The range is limited from 0.85 to 1.3. Set to None to disable'),
+                        'global_df_mod': Param(1.0, VT.number, 'The multiplier for the current distance used by dynamic follow. The range is limited from 0.85 to 1.2\n'
+                                                               'Smaller values will get you closer, larger will get you farther\n'
+                                                               'This is multiplied by any profile that\'s active. Set to 1. to disable'),
+                        'min_TR': Param(0.9, VT.number, 'The minimum allowed following distance in seconds. Default is 0.9 seconds.\n'
+                                                        'The range is limited from 0.85 to 1.6.'),
                         'alca_nudge_required': Param(True, bool, 'Whether to wait for applied torque to the wheel (nudge) before making lane changes. '
                                                                  'If False, lane change will occur IMMEDIATELY after signaling'),
                         'alca_min_speed': Param(25.0, VT.number, 'The minimum speed allowed for an automatic lane change (in MPH)'),

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -138,7 +138,7 @@ class opParams:
     if param_info.is_valid(value):  # always valid if no allowed types, otherwise checks to make sure
       return value  # all good, returning user's value
 
-    warning('User\'s value type is not valid!')  # somehow... it should always be valid
+    warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
     return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):

--- a/op_edit.py
+++ b/op_edit.py
@@ -60,11 +60,12 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       values_list = []
       for k, v in self.params.items():
         if len(str(v)) < 20:
+          v_color = ''
           if type(v) in self.type_colors:
             v_color = self.type_colors[type(v)]
             if isinstance(v, bool):
               v_color = v_color[v]
-            v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
+          v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
         else:
           v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
@@ -72,12 +73,15 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       live = [COLORS.BASE(157) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
+      blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:
           line = COLORS.OKGREEN + line
         else:
-          line = COLORS.CYAN + line
+          _color = blue_grad[min(round(idx / len(self.params) * len(blue_grad)), len(blue_grad) - 1)]
+          # line = COLORS.CYAN + line
+          line = COLORS.BASE(_color) + line
         to_print.append(line)
 
       extras = {'a': 'Add new parameter',

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(180), float: COLORS.BASE(180),  # or 180 or 215, 6, 173, 179, 180,
+    self.type_colors = {int: COLORS.BASE(208), float: COLORS.BASE(208),  # or 180 or 215, 6, 173, 179, 180,
                         bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
 
     self.last_choice = None

--- a/op_edit.py
+++ b/op_edit.py
@@ -62,7 +62,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         if len(str(v)) < 20:
           if type(v) in self.type_colors:
             v_color = self.type_colors[type(v)]
-            if isinstance(type(v), bool):
+            if isinstance(v, bool):
               v_color = v_color[v]
             v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
         else:

--- a/op_edit.py
+++ b/op_edit.py
@@ -5,7 +5,6 @@ import ast
 import difflib
 from common.colors import COLORS
 
-# noinspection PyCallByClass
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def __init__(self):
     self.op_params = opParams()

--- a/op_edit.py
+++ b/op_edit.py
@@ -74,7 +74,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
 
       to_print = []
       # blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
-      blue_grad = [27, 33, 39, 45, 51, 87]
+      blue_grad = [33, 39, 45, 51, 87]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:

--- a/op_edit.py
+++ b/op_edit.py
@@ -70,7 +70,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
 
-      live = [COLORS.BASEBG(200) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASEBG(93) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       blue_gradient = [33, 39, 45, 51, 87]

--- a/op_edit.py
+++ b/op_edit.py
@@ -6,27 +6,6 @@ import difflib
 from common.colors import COLORS
 
 
-# class STYLES:  # todo: use common.colors
-#   # HEADER = '\033[95m'
-#   # OKBLUE = '\033[94m'
-#   # CBLUE = '\33[44m'
-#   # BOLD = '\033[1m'
-#   OKGREEN = '\033[92m'
-#   CWHITE = '\33[37m'
-#   ENDC = '\033[0m' + CWHITE
-#   UNDERLINE = '\033[4m'
-#
-#   RED = '\033[91m'
-#   PURPLE_BG = '\33[45m'
-#   YELLOW = '\033[93m'
-#
-#   FAIL = RED
-#   INFO = PURPLE_BG
-#   SUCCESS = OKGREEN
-#   PROMPT = YELLOW
-#   CYAN = '\033[36m'
-
-
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def __init__(self):
     self.op_params = opParams()

--- a/op_edit.py
+++ b/op_edit.py
@@ -53,7 +53,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       if self.live_tuning:  # only display live tunable params
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
-      values_list = [COLORS.BASE(119) + v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
+      values_list = [COLORS.BASE(119) + str(v) if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
       live = [COLORS.BASE(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,8 +13,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(137), float: COLORS.BASE(137),  # or 180 or 215
-                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}  # or 134, 171, 176, 177, (207, 207 looks prettier), 213, 219
+    self.type_colors = {int: COLORS.BASE(6), float: COLORS.BASE(6),  # or 180 or 215, 6, 173, 179, 180,
+                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -61,6 +61,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         v = str(v)
         if len(v) < 20:
           if v_type in self.type_colors:
+            print(v_type)
+            print(self.type_colors[v_type])
             v = '{}{}{}'.format(self.type_colors[v_type], v, COLORS.ENDC)
         else:
           v = '{} ... {}'.format(v[:30], v[-15:])

--- a/op_edit.py
+++ b/op_edit.py
@@ -54,7 +54,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
       values_list = [v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
-      live = [COLORS.BASE.format(154) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASE.format(147) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       for idx, param in enumerate(self.params):

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {str: COLORS.BASE(137)}  # or 180 or 215
+    self.type_colors = {int: COLORS.BASE(137), float: COLORS.BASE(137)}  # or 180 or 215
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(6), float: COLORS.BASE(6),  # or 180 or 215, 6, 173, 179, 180,
+    self.type_colors = {int: COLORS.ENDC + COLORS.BASE(6), float: COLORS.ENDC + COLORS.BASE(6),  # or 180 or 215, 6, 173, 179, 180,
                         bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
 
     self.last_choice = None

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,6 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
+    self.type_colors = {str: COLORS.BASE(137)}  # or 180 or 215
 
     self.last_choice = None
 
@@ -53,7 +54,17 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       if self.live_tuning:  # only display live tunable params
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
-      values_list = [COLORS.BASE(119) + str(v) if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
+      values_list = []
+      for k, v in self.params.items():
+        v_type = type(v)
+        v = str(v)
+        if len(v) < 20:
+          if v_type in self.type_colors:
+            v = '{}{}{}'.format(self.type_colors[v_type], v, COLORS.ENDC)
+        else:
+          v = '{} ... {}'.format(v[:30], v[-15:])
+        values_list.append(v)
+
       live = [COLORS.BASE(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []

--- a/op_edit.py
+++ b/op_edit.py
@@ -14,7 +14,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
     self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
-                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
+                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177),
+                        str: COLORS.BASE(2)}  # 107, 108, 2
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -83,12 +83,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
               v_color = self.type_colors[type(v)]
               if isinstance(v, bool):
                 v_color = v_color[v]
-              v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
-          else:
-            v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
 
-
-          line = COLORS.CYAN + line
+          line = v_color + line
         to_print.append(line)
 
       extras = {'a': 'Add new parameter',

--- a/op_edit.py
+++ b/op_edit.py
@@ -66,7 +66,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           v = '{} ... {}'.format(v[:30], v[-15:])
         values_list.append(v)
 
-      live = [COLORS.BASE(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASE(157) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       for idx, param in enumerate(self.params):

--- a/op_edit.py
+++ b/op_edit.py
@@ -83,12 +83,14 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           line = COLORS.BASE(_color) + line
         to_print.append(line)
 
-      extras = {'a': '{}Add new parameter{}'.format(COLORS.OKGREEN, COLORS.ENDC),
-                'd': '{}Delete parameter{}'.format(COLORS.FAIL, ''),
+      extras = {'a': 'Add new parameter',
+                'd': 'Delete parameter',
                 'l': 'Toggle live tuning',
                 'e': 'Exit opEdit'}
 
-      to_print += ['---'] + ['{}. {}'.format(e, extras[e]) for e in extras]
+      extras_colors = [COLORS.OKGREEN, COLORS.FAIL, COLORS.WARNING, COLORS.PINK]
+
+      to_print += ['---'] + ['{}{}. {}'.format(ext_col, e, extras[e], COLORS.ENDC) for e, ext_col in zip(extras, extras_colors)]
       print('\n'.join(to_print))
       self.prompt('\nChoose a parameter to edit (by index or name):')
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,10 +13,10 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
+    self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),
                         bool: {False: COLORS.RED, True: COLORS.OKGREEN},
                         type(None): COLORS.BASE(177),
-                        str: COLORS.BASE(77)}  # 107, 108, 77, 113, 149
+                        str: COLORS.BASE(77)}
 
     self.last_choice = None
 
@@ -87,7 +87,6 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
                 'd': 'Delete parameter',
                 'l': 'Toggle live tuning',
                 'e': 'Exit opEdit'}
-
       extras_colors = [COLORS.OKGREEN, COLORS.FAIL, COLORS.WARNING, COLORS.PINK]
 
       to_print += ['---'] + ['{}{}. {}'.format(ext_col, e, extras[e], COLORS.ENDC) for e, ext_col in zip(extras, extras_colors)]

--- a/op_edit.py
+++ b/op_edit.py
@@ -53,7 +53,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       if self.live_tuning:  # only display live tunable params
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
-      values_list = [v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
+      values_list = [COLORS.BASE(119) + v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
       live = [COLORS.BASE.format(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []

--- a/op_edit.py
+++ b/op_edit.py
@@ -83,7 +83,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           line = COLORS.BASE(_color) + line
         to_print.append(line)
 
-      extras = {'a': 'Add new parameter',
+      extras = {'a': '{}Add new parameter{}'.format(COLORS.OKGREEN, COLORS.ENDC),
                 'd': 'Delete parameter',
                 'l': 'Toggle live tuning',
                 'e': 'Exit opEdit'}

--- a/op_edit.py
+++ b/op_edit.py
@@ -6,6 +6,7 @@ import difflib
 from common.colors import COLORS
 
 
+# noinspection PyCallByClass
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def __init__(self):
     self.op_params = opParams()
@@ -54,7 +55,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
       values_list = [COLORS.BASE(119) + v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
-      live = [COLORS.BASE.format(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASE(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       for idx, param in enumerate(self.params):

--- a/op_edit.py
+++ b/op_edit.py
@@ -70,18 +70,16 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
 
-      live = [COLORS.BASE(157) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASEBG(200) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
-      # blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
-      blue_grad = [33, 39, 45, 51, 87]
+      blue_gradient = [33, 39, 45, 51, 87]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:
           line = COLORS.OKGREEN + line
         else:
-          _color = blue_grad[min(round(idx / len(self.params) * len(blue_grad)), len(blue_grad) - 1)]
-          # line = COLORS.CYAN + line
+          _color = blue_gradient[min(round(idx / len(self.params) * len(blue_gradient)), len(blue_gradient) - 1)]
           line = COLORS.BASE(_color) + line
         to_print.append(line)
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -5,7 +5,6 @@ import ast
 import difflib
 from common.colors import COLORS
 
-
 # noinspection PyCallByClass
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def __init__(self):

--- a/op_edit.py
+++ b/op_edit.py
@@ -54,7 +54,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
       values_list = [v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
-      live = [COLORS.BASE.format(147) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASE.format(205) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       for idx, param in enumerate(self.params):

--- a/op_edit.py
+++ b/op_edit.py
@@ -83,13 +83,12 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           line = COLORS.BASE(_color) + line
         to_print.append(line)
 
-      extras = {'a': 'Add new parameter',
-                'd': 'Delete parameter',
-                'l': 'Toggle live tuning',
-                'e': 'Exit opEdit'}
-      extras_colors = [COLORS.OKGREEN, COLORS.FAIL, COLORS.WARNING, COLORS.PINK]
+      extras = {'a': ('Add new parameter', COLORS.OKGREEN),
+                'd': ('Delete parameter', COLORS.FAIL),
+                'l': ('Toggle live tuning', COLORS.WARNING),
+                'e': ('Exit opEdit', COLORS.PINK)}
 
-      to_print += ['---'] + ['{}{}. {}'.format(ext_col, e, extras[e], COLORS.ENDC) for e, ext_col in zip(extras, extras_colors)]
+      to_print += ['---'] + ['{}. {}'.format(ext_col + e, ext_txt + COLORS.ENDC) for e, (ext_txt, ext_col) in extras.items()]
       print('\n'.join(to_print))
       self.prompt('\nChoose a parameter to edit (by index or name):')
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(208), float: COLORS.BASE(208),  # or 180 or 215, 6, 173, 179, 180,
+    self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
                         bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
 
     self.last_choice = None

--- a/op_edit.py
+++ b/op_edit.py
@@ -54,7 +54,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
       values_list = [v if len(str(v)) < 20 else '{} ... {}'.format(str(v)[:30], str(v)[-15:]) for k, v in self.params.items()]
-      live = [COLORS.BASE.format(205) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASE.format(213) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       for idx, param in enumerate(self.params):

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.BASE(137), float: COLORS.BASE(137)}  # or 180 or 215
+    self.type_colors = {int: COLORS.BASE(137), float: COLORS.BASE(137),  # or 180 or 215
+                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}  # or 134, 171, 176, 177, (207, 207 looks prettier), 213, 219
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -77,6 +77,17 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         if idx == self.last_choice and self.last_choice is not None:
           line = COLORS.OKGREEN + line
         else:
+          v = self.params[param]
+          if len(str(v)) < 20:
+            if type(v) in self.type_colors:
+              v_color = self.type_colors[type(v)]
+              if isinstance(v, bool):
+                v_color = v_color[v]
+              v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
+          else:
+            v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
+
+
           line = COLORS.CYAN + line
         to_print.append(line)
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -74,7 +74,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
 
       to_print = []
       # blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
-      blue_grad = [33, 39, 45, 51, 80, 81, 87, 123]
+      blue_grad = [27, 33, 39, 45, 51, 87]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:

--- a/op_edit.py
+++ b/op_edit.py
@@ -16,7 +16,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
                         bool: {False: COLORS.RED, True: COLORS.OKGREEN},
                         type(None): COLORS.BASE(177),
-                        str: COLORS.BASE(113)}  # 107, 108, 77, 113, 149
+                        str: COLORS.BASE(77)}  # 107, 108, 77, 113, 149
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -13,7 +13,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.sleep_time = 0.75
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
-    self.type_colors = {int: COLORS.ENDC + COLORS.BASE(6), float: COLORS.ENDC + COLORS.BASE(6),  # or 180 or 215, 6, 173, 179, 180,
+    self.type_colors = {int: COLORS.BASE(180), float: COLORS.BASE(180),  # or 180 or 215, 6, 173, 179, 180,
                         bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177)}
 
     self.last_choice = None

--- a/op_edit.py
+++ b/op_edit.py
@@ -16,7 +16,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
                         bool: {False: COLORS.RED, True: COLORS.OKGREEN},
                         type(None): COLORS.BASE(177),
-                        str: COLORS.BASE(149)}  # 107, 108, 77, 113, 149
+                        str: COLORS.BASE(113)}  # 107, 108, 77, 113, 149
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -77,14 +77,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         if idx == self.last_choice and self.last_choice is not None:
           line = COLORS.OKGREEN + line
         else:
-          v = self.params[param]
-          if len(str(v)) < 20:
-            if type(v) in self.type_colors:
-              v_color = self.type_colors[type(v)]
-              if isinstance(v, bool):
-                v_color = v_color[v]
-
-          line = v_color + line
+          line = COLORS.CYAN + line
         to_print.append(line)
 
       extras = {'a': 'Add new parameter',

--- a/op_edit.py
+++ b/op_edit.py
@@ -5,6 +5,7 @@ import ast
 import difflib
 from common.colors import COLORS
 
+
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def __init__(self):
     self.op_params = opParams()

--- a/op_edit.py
+++ b/op_edit.py
@@ -14,7 +14,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.live_tuning = self.op_params.get('op_edit_live_mode')
     self.username = self.op_params.get('username')
     self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
-                        bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177),
+                        bool: {False: COLORS.RED, True: COLORS.OKGREEN},
+                        type(None): COLORS.BASE(177),
                         str: COLORS.BASE(149)}  # 107, 108, 77, 113, 149
 
     self.last_choice = None
@@ -58,15 +59,14 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
 
       values_list = []
       for k, v in self.params.items():
-        v_type = type(v)
-        v = str(v)
-        if len(v) < 20:
-          if v_type in self.type_colors:
-            print(v_type)
-            print(self.type_colors[v_type])
-            v = '{}{}{}'.format(self.type_colors[v_type], v, COLORS.ENDC)
+        if len(str(v)) < 20:
+          if type(v) in self.type_colors:
+            v_color = self.type_colors[type(v)]
+            if isinstance(type(v), bool):
+              v_color = v_color[v]
+            v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
         else:
-          v = '{} ... {}'.format(v[:30], v[-15:])
+          v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
 
       live = [COLORS.BASE(157) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]

--- a/op_edit.py
+++ b/op_edit.py
@@ -70,7 +70,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
 
-      live = [COLORS.BASEBG(93) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.BASEBG(127) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       blue_gradient = [33, 39, 45, 51, 87]

--- a/op_edit.py
+++ b/op_edit.py
@@ -84,7 +84,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
         to_print.append(line)
 
       extras = {'a': '{}Add new parameter{}'.format(COLORS.OKGREEN, COLORS.ENDC),
-                'd': 'Delete parameter',
+                'd': '{}Delete parameter{}'.format(COLORS.FAIL, ''),
                 'l': 'Toggle live tuning',
                 'e': 'Exit opEdit'}
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -70,7 +70,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
           v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
         values_list.append(v)
 
-      live = [COLORS.BASEBG(127) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
+      live = [COLORS.INFO + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
       blue_gradient = [33, 39, 45, 51, 87]

--- a/op_edit.py
+++ b/op_edit.py
@@ -15,7 +15,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.username = self.op_params.get('username')
     self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),  # or 180 or 215, 6, 173, 179, 180,
                         bool: COLORS.CITALIC + COLORS.BASE(177), type(None): COLORS.CITALIC + COLORS.BASE(177),
-                        str: COLORS.BASE(2)}  # 107, 108, 2
+                        str: COLORS.BASE(149)}  # 107, 108, 77, 113, 149
 
     self.last_choice = None
 

--- a/op_edit.py
+++ b/op_edit.py
@@ -73,7 +73,8 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       live = [COLORS.BASE(157) + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
-      blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
+      # blue_grad = [27, 33, 39, 45, 51, 80, 81, 87, 123]
+      blue_grad = [33, 39, 45, 51, 80, 81, 87, 123]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -32,7 +32,7 @@ class CarInterfaceBase():
     self.CC = None
     if CarController is not None:
       self.CC = CarController(self.cp.dbc_name, CP, self.VM)
-    self.disengage_on_gas = opParams().get('disengage_on_gas', default=True)
+    self.disengage_on_gas = opParams().get('disengage_on_gas')
 
   @staticmethod
   def calc_accel_override(a_ego, a_target, v_ego, v_target):

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -7,7 +7,9 @@ from selfdrive.swaglog import cloudlog
 from selfdrive.car.interfaces import CarInterfaceBase
 from common.op_params import opParams
 
-prius_use_lqr = opParams().get('prius_use_lqr')
+op_params = opParams()
+prius_use_lqr = op_params.get('prius_use_lqr')
+corolla_use_lqr = op_params.get('corolla_use_lqr')
 EventName = car.CarEvent.EventName
 
 class CarInterface(CarInterfaceBase):
@@ -42,7 +44,11 @@ class CarInterface(CarInterfaceBase):
       ret.longitudinalTuning.kpV = [3.6, 2.4, 1.5]
       ret.longitudinalTuning.kiV = [0.54, 0.36]
 
-    if candidate not in [CAR.PRIUS, CAR.RAV4, CAR.RAV4H, CAR.COROLLA]:  # These cars use LQR/INDI
+    cars_not_pid = [CAR.PRIUS, CAR.RAV4, CAR.RAV4H]
+    if corolla_use_lqr:
+      cars_not_pid.append(CAR.COROLLA)
+
+    if candidate not in cars_not_pid:  # These cars use LQR/INDI
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
 
@@ -103,17 +109,22 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 18.27
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
-      ret.lateralTuning.init('lqr')
 
-      ret.lateralTuning.lqr.scale = 1500.0
-      ret.lateralTuning.lqr.ki = 0.05
+      if corolla_use_lqr:
+        ret.lateralTuning.init('lqr')
 
-      ret.lateralTuning.lqr.a = [0., 1., -0.22619643, 1.21822268]
-      ret.lateralTuning.lqr.b = [-1.92006585e-04, 3.95603032e-05]
-      ret.lateralTuning.lqr.c = [1., 0.]
-      ret.lateralTuning.lqr.k = [-110.73572306, 451.22718255]
-      ret.lateralTuning.lqr.l = [0.3233671, 0.3185757]
-      ret.lateralTuning.lqr.dcGain = 0.002237852961363602
+        ret.lateralTuning.lqr.scale = 1500.0
+        ret.lateralTuning.lqr.ki = 0.05
+
+        ret.lateralTuning.lqr.a = [0., 1., -0.22619643, 1.21822268]
+        ret.lateralTuning.lqr.b = [-1.92006585e-04, 3.95603032e-05]
+        ret.lateralTuning.lqr.c = [1., 0.]
+        ret.lateralTuning.lqr.k = [-110.73572306, 451.22718255]
+        ret.lateralTuning.lqr.l = [0.3233671, 0.3185757]
+        ret.lateralTuning.lqr.dcGain = 0.002237852961363602
+      else:
+        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
+        ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -7,7 +7,7 @@ from selfdrive.swaglog import cloudlog
 from selfdrive.car.interfaces import CarInterfaceBase
 from common.op_params import opParams
 
-prius_use_lqr = opParams().get('prius_use_lqr', False)
+prius_use_lqr = opParams().get('prius_use_lqr')
 EventName = car.CarEvent.EventName
 
 class CarInterface(CarInterfaceBase):

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -60,8 +60,8 @@ class Controls:
 
     self.op_params = opParams()
     self.df_manager = dfManager(self.op_params)
-    self.hide_auto_df_alerts = self.op_params.get('hide_auto_df_alerts', False)
-    self.support_white_panda = self.op_params.get('support_white_panda', False)
+    self.hide_auto_df_alerts = self.op_params.get('hide_auto_df_alerts')
+    self.support_white_panda = self.op_params.get('support_white_panda')
     self.last_model_long = False
 
     self.can_sock = can_sock
@@ -484,7 +484,7 @@ class Controls:
     if len(meta.desirePrediction) and ldw_allowed:
       l_lane_change_prob = meta.desirePrediction[Desire.laneChangeLeft - 1]
       r_lane_change_prob = meta.desirePrediction[Desire.laneChangeRight - 1]
-      CAMERA_OFFSET = self.op_params.get('camera_offset', 0.06)
+      CAMERA_OFFSET = self.op_params.get('camera_offset')
       l_lane_close = left_lane_visible and (self.sm['pathPlan'].lPoly[3] < (1.08 - CAMERA_OFFSET))
       r_lane_close = right_lane_visible and (self.sm['pathPlan'].rPoly[3] > -(1.08 + CAMERA_OFFSET))
 

--- a/selfdrive/controls/lib/dynamic_follow/__init__.py
+++ b/selfdrive/controls/lib/dynamic_follow/__init__.py
@@ -48,7 +48,7 @@ class DynamicFollow:
 
   def _setup_collector(self):
     self.sm_collector = SubMaster(['liveTracks', 'laneSpeed'])
-    self.log_auto_df = self.op_params.get('log_auto_df', False)
+    self.log_auto_df = self.op_params.get('log_auto_df')
     if not isinstance(self.log_auto_df, bool):
       self.log_auto_df = False
     self.data_collector = DataCollector(file_path='/data/df_data', keys=['v_ego', 'a_ego', 'a_lead', 'v_lead', 'x_lead', 'left_lane_speeds', 'middle_lane_speeds', 'right_lane_speeds', 'left_lane_distances', 'middle_lane_distances', 'right_lane_distances', 'profile', 'time'], log_data=self.log_auto_df)
@@ -209,7 +209,7 @@ class DynamicFollow:
     This function modifies the y_dist list used by dynamic follow in accordance with global_df_mod
     It also intelligently adjusts the profile mods at each breakpoint based on the change in TR
     """
-    if self.global_df_mod is None:
+    if self.global_df_mod == 1.:
       return profile_mod_pos, profile_mod_neg, y_dist
     global_df_mod = 1 - self.global_df_mod
 
@@ -319,12 +319,10 @@ class DynamicFollow:
     self.car_data.cruise_enabled = CS.cruiseState.enabled
 
   def _get_live_params(self):
-    self.global_df_mod = self.op_params.get('global_df_mod', None)
-    if self.global_df_mod is not None:
+    self.global_df_mod = self.op_params.get('global_df_mod')
+    if self.global_df_mod != 1.:
       self.global_df_mod = clip(self.global_df_mod, 0.85, 1.2)
 
-    self.min_TR = self.op_params.get('min_TR', None)
-    if self.min_TR is not None:
-      self.min_TR = clip(self.min_TR, 0.85, 1.3)
-    else:
-      self.min_TR = 0.9  # default
+    self.min_TR = self.op_params.get('min_TR')
+    if self.min_TR != 1.:
+      self.min_TR = clip(self.min_TR, 0.85, 1.6)

--- a/selfdrive/controls/lib/dynamic_follow/df_manager.py
+++ b/selfdrive/controls/lib/dynamic_follow/df_manager.py
@@ -20,7 +20,7 @@ class dfManager:
     self.df_profiles = dfProfiles()
     self.sm = messaging.SubMaster(['dynamicFollowButton', 'dynamicFollowData'])
 
-    self.cur_user_profile = self.op_params.get('dynamic_follow', default='auto').strip().lower()
+    self.cur_user_profile = self.op_params.get('dynamic_follow').strip().lower()
     if not isinstance(self.cur_user_profile, str) or self.cur_user_profile not in self.df_profiles.to_idx:
       self.cur_user_profile = self.df_profiles.default  # relaxed
     else:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -53,7 +53,7 @@ class DynamicCameraOffset:
     self.sm = SubMaster(['laneSpeed'])
     self.pm = PubMaster(['dynamicCameraOffset'])
     self.op_params = opParams()
-    self.camera_offset = self.op_params.get('camera_offset', 0.06)
+    self.camera_offset = self.op_params.get('camera_offset')
 
     self.left_lane_oncoming = False  # these variables change
     self.right_lane_oncoming = False
@@ -65,14 +65,14 @@ class DynamicCameraOffset:
     self._setup_static()
 
   def _setup_static(self):  # these variables are static
-    self._enabled = self.op_params.get('dynamic_camera_offset', True)
+    self._enabled = self.op_params.get('dynamic_camera_offset')
     self._min_enable_speed = 35 * CV.MPH_TO_MS
     self._min_lane_width_certainty = 0.4
     self._hug_left_ratio = 0.375
     self._hug_right_ratio = 0.625
     self._center_ratio = 0.5
 
-    self._keep_offset_for = self.op_params.get('dynamic_camera_offset_time', 2.5)  # seconds after losing oncoming lane
+    self._keep_offset_for = self.op_params.get('dynamic_camera_offset_time')  # seconds after losing oncoming lane
     self._ramp_angles = [0, 12.5, 25]
     self._ramp_angle_mods = [1, 0.85, 0.1]  # multiply offset by this based on angle
 
@@ -89,7 +89,7 @@ class DynamicCameraOffset:
   def update(self, v_ego, active, angle_steers, lane_width_estimate, lane_width_certainty, polys, probs):
     if self._enabled:
       self.sm.update(0)
-      self.camera_offset = self.op_params.get('camera_offset', 0.06)  # update base offset from user
+      self.camera_offset = self.op_params.get('camera_offset')  # update base offset from user
       self.left_lane_oncoming = self.sm['laneSpeed'].leftLaneOncoming
       self.right_lane_oncoming = self.sm['laneSpeed'].rightLaneOncoming
       self.lane_width_estimate, self.lane_width_certainty = lane_width_estimate, lane_width_certainty

--- a/selfdrive/controls/lib/lane_speed.py
+++ b/selfdrive/controls/lib/lane_speed.py
@@ -72,7 +72,7 @@ class LaneSpeed:
     self._setup()
 
   def _setup(self):
-    self.ls_state = self.op_params.get('lane_speed_alerts', 'audible').strip().lower()
+    self.ls_state = self.op_params.get('lane_speed_alerts').strip().lower()
     if not isinstance(self.ls_state, str) or self.ls_state not in LaneSpeedState.to_idx:
       self.ls_state = LaneSpeedState.audible
       self.op_params.put('lane_speed_alerts', LaneSpeedState.to_state[self.ls_state])

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -77,7 +77,7 @@ class LongControl():
     self.last_output_gb = 0.0
 
     self.op_params = opParams()
-    self.enable_dg = self.op_params.get('dynamic_gas', True)
+    self.enable_dg = self.op_params.get('dynamic_gas')
     self.dynamic_gas = DynamicGas(CP, candidate)
 
   def reset(self, v_pid):

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -64,8 +64,8 @@ class PathPlanner():
     self.prev_one_blinker = False
 
     self.op_params = opParams()
-    self.alca_nudge_required = self.op_params.get('alca_nudge_required', default=True)
-    self.alca_min_speed = self.op_params.get('alca_min_speed', default=30.0) * CV.MPH_TO_MS
+    self.alca_nudge_required = self.op_params.get('alca_nudge_required')
+    self.alca_min_speed = self.op_params.get('alca_min_speed') * CV.MPH_TO_MS
 
   def setup_mpc(self):
     self.libmpc = libmpc_py.libmpc

--- a/selfdrive/controls/lib/pid.py
+++ b/selfdrive/controls/lib/pid.py
@@ -94,7 +94,7 @@ class PIController():
 class PIDController:
   def __init__(self, k_p, k_i, k_d, k_f=1., pos_limit=None, neg_limit=None, rate=100, sat_limit=0.8, convert=None):
     self.op_params = opParams()
-    self.enable_long_derivative = self.op_params.get('enable_long_derivative', False)
+    self.enable_long_derivative = self.op_params.get('enable_long_derivative')
     self._k_p = k_p  # proportional gain
     self._k_i = k_i  # integral gain
     self._k_d = k_d  # derivative gain

--- a/selfdrive/controls/lib/vehicle_model.py
+++ b/selfdrive/controls/lib/vehicle_model.py
@@ -37,14 +37,14 @@ class VehicleModel:
     self.cR_orig = CP.tireStiffnessRear
 
     self.op_params = opParams()
-    self.steer_ratio = self.op_params.get('steer_ratio', default=None)
+    self.steer_ratio = self.op_params.get('steer_ratio')
     self.sR = CP.steerRatio
 
     self.update_params(1.0, CP.steerRatio)
 
   def update_params(self, stiffness_factor: float, steer_ratio: float) -> None:
     """Update the vehicle model with a new stiffness factor and steer ratio"""
-    self.steer_ratio = self.op_params.get('steer_ratio', default=None)
+    self.steer_ratio = self.op_params.get('steer_ratio')
     self.cF = stiffness_factor * self.cF_orig
     self.cR = stiffness_factor * self.cR_orig
     if type(self.steer_ratio) in [int, float]:

--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -47,7 +47,7 @@ else:
     os.mkdir(CRASHES_DIR)
 
   error_tags = {'dirty': dirty, 'origin': origin, 'branch': branch, 'commit': commit}
-  username = opParams().get('username', None)
+  username = opParams().get('username')
   if username is None or not isinstance(username, str):
     username = 'undefined'
   error_tags['username'] = username

--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -53,7 +53,7 @@ else:
   error_tags['username'] = username
 
   sentry_uri = 'https://1994756b5e6f41cf939a4c65de45f4f2:cefebaf3a8aa40d182609785f7189bd7@app.getsentry.com/77924'  # stock
-  if 'github.com/shanesmiskol' in origin.lower():  # only send errors if my fork
+  if 'github.com/shanesmiskol' in origin.lower():  # CHANGE TO YOUR remote and sentry key to receive errors if you fork this fork
     sentry_uri = 'https://7f66878806a948f9a8b52b0fe7781201@o237581.ingest.sentry.io/5252098'
   client = Client(sentry_uri,
                   install_sys_hook=False, transport=HTTPTransport, release=version, tags=error_tags)

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -24,7 +24,7 @@ UPLOAD_ATTR_NAME = 'user.upload'
 UPLOAD_ATTR_VALUE = b'1'
 
 fake_upload = os.getenv("FAKEUPLOAD") is not None
-upload_on_hotspot = opParams().get('upload_on_hotspot', default=False)
+upload_on_hotspot = opParams().get('upload_on_hotspot')
 
 def raise_on_thread(t, exctype):
   '''Raises an exception in the threads with id tid'''

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -24,7 +24,7 @@ TOTAL_SCONS_NODES = 1020
 prebuilt = os.path.exists(os.path.join(BASEDIR, 'prebuilt'))
 
 op_params = opParams()
-no_ota_updates = op_params.get('no_ota_updates', False) or os.path.exists('/data/no_ota_updates')
+no_ota_updates = op_params.get('no_ota_updates') or os.path.exists('/data/no_ota_updates')
 
 # Create folders needed for msgq
 try:


### PR DESCRIPTION
- Use new Param class to clean up default_params -> fork_params
- Disallow .get() if param doesn't exist in fork params (don't silently use default value unexpectedly)
  - If user's param value type is invalid, use default value
- Disallow .put() if param doesn't exist in fork params
  - Disallow putting invalid value type
- opEdit coloring improvements
- Checks user's parameter value types on initialization, resets to default value if user's value type isn't in allowed_types
- default value arg is now required