### PR TITLE
Show changelog to user instead of rebooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here are the main parameters you can change with this fork:
   - `alca_nudge_required`: Whether to wait for applied torque to the wheel (nudge) before making lane changes
   - `alca_min_speed`: The minimum speed allowed for an automatic lane change
   - `upload_on_hotspot`: Controls whether your EON will upload driving data on your phone's hotspot
-  - [`no_ota_updates`](#Automatic-updates): Set this to True to disable all automatic updates. Reboot to take effect
+  - [`auto_update`](#Automatic-updates): Toggles whether your device will update and reboot automatically on this fork
   - `disengage_on_gas`: Whether you want openpilot to disengage on gas input or not
 - **Dynamic params**:
   - `dynamic_gas`: Whether to use [dynamic gas](#dynamic-gas) if your car is supported

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Parameters are stored at `/data/op_params.json`
 ---
 ### Automatic updates
 When a new update is available on GitHub for Stock Additions, your EON/C2 will pull and reset your local branch to the remote. It then queues a reboot to occur when the following is true:
-- your EON has been inactive or offroad for more than 5 minutes.
+- your EON has been inactive or offroad for more than 5 minutes
 
 Therefore, if your device sees an update while you're driving it will reboot approximately 5 to 10 minutes after you finish your drive, it resets the timer if you start driving again before the time is up.
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,16 +1,6 @@
 Stock Additions v0.1.1 (0.7.7)
 ===
  * Disable automatic updates by default and show changelog to users in apk
- * LaneSpeed process is much more efficient, CPU usage down from 6% (causing lag alerts) to ~1%
-   * Use numpy_fast.interp instead of np.interp for slight boost in performance
- * Support white panda with experimental parameter. localizer performance may be reduced
- * Fixed silent alerts due to the new alert manager in 0.7.7
- * Make all the UI buttons show their state with unique colors!
-   * Also added more colors to opEdit!
- * Add derivative to lateral PI control for TSS1 & TSS2 Corolla and Prius!
- * Add a Reset to origin button to TextWindow when an error occurs
- * Color coded model lane lines and path
- * Add ZSS support
 
 Stock Additions v0.1 (0.7.7)
 ===

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,4 +1,4 @@
-Stock Additions v0.1.1 (2020-9-10, 0.7.7)
+Stock Additions v0.1.1 (2020-9-10) - 0.7.7
 ===
  * Disable automatic updates by default and show changelog to users in apk
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,4 +1,4 @@
-Stock Additions v0.1.1 - 0.7.7 (2020-9-10)
+Stock Additions v0.1.1 - 2020-9-10 (0.7.7)
 ===
  * Disable automatic updates by default and show changelog to users in apk
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,4 +1,4 @@
-Stock Additions v0.1.1 (2020-9-10) - 0.7.7
+Stock Additions v0.1.1 - 0.7.7 (2020-9-10)
 ===
  * Disable automatic updates by default and show changelog to users in apk
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,4 +1,4 @@
-Stock Additions v0.1.1 (0.7.7)
+Stock Additions v0.1.1 (2020-9-10, 0.7.7)
 ===
  * Disable automatic updates by default and show changelog to users in apk
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,5 +1,9 @@
-Stock Additions 0.7.7
-========================
+Stock Additions v0.1.1 (0.7.7)
+===
+ * Disable automatic updates by default and show changelog to users in apk
+
+Stock Additions v0.1 (0.7.7)
+===
  * LaneSpeed process is much more efficient, CPU usage down from 6% (causing lag alerts) to ~1%
    * Use numpy_fast.interp instead of np.interp for slight boost in performance
  * Support white panda with experimental parameter. localizer performance may be reduced
@@ -12,7 +16,7 @@ Stock Additions 0.7.7
  * Add ZSS support
 
 Stock Additions 0.7.5
-========================
+===
  * Various opEdit improvements, colors, highlighting of last explored param, quicker messages
  * New Dynamic Follow modification to help slow and accelerate sooner
  * Live parameters update quicker
@@ -20,12 +24,12 @@ Stock Additions 0.7.5
  * New LaneSpeed and Dynamic Camera Offset features added
 
 Stock Additions 0.7.4 (version 0.2)
-========================
+===
  * Sidebar will not pop out when you tap the Dynamic Follow profile change button when driving
  * Add derivative to longcontrol. Improves responsiveness and helps overshoot
 
 Stock Additions 0.7.1
-========================
+===
  * Recover faster when lead leaves path, or when braking or acceleration is required immediately. Also should speed up the acceleration with auto lane change.
  * Add 3 different dynamic follow profiles: `roadtrip`, `relaxed`, and `traffic`. `relaxed` is the current dynamic follow profile. You can also swap profiles without rebooting live by using opEdit. SSH in and: `cd /data/openpilot;python op_edit.py` The parameter to change is `dynamic_follow`
  * Fix for steering unavailable when wheel goes over 100 degrees/sec.
@@ -35,7 +39,7 @@ Stock Additions 0.7.1
  * Automatic updates, EON will reboot by itself as long as it is inactive
 
 Stock Additions 0.7
-========================
+===
  * Dynamic lane speed is a new feature that reduces your cruising speed if many vehicles around you are significantly slower than you. This works with and without an openpilot-identified lead.
  * Dynamic gas tuning. Above 20 mph we take lead velocity and the following distance into account. Possibility of different tuning for different cars in the future. (DYNAMIC GAS NOW ONLY WORKS ON TOYOTA COROLLA AND RAV4 PEDAL)
  * Dynamic follow tuning, don't get as close when lead is accelerating.

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,6 +1,16 @@
 Stock Additions v0.1.1 (0.7.7)
 ===
  * Disable automatic updates by default and show changelog to users in apk
+ * LaneSpeed process is much more efficient, CPU usage down from 6% (causing lag alerts) to ~1%
+   * Use numpy_fast.interp instead of np.interp for slight boost in performance
+ * Support white panda with experimental parameter. localizer performance may be reduced
+ * Fixed silent alerts due to the new alert manager in 0.7.7
+ * Make all the UI buttons show their state with unique colors!
+   * Also added more colors to opEdit!
+ * Add derivative to lateral PI control for TSS1 & TSS2 Corolla and Prius!
+ * Add a Reset to origin button to TextWindow when an error occurs
+ * Color coded model lane lines and path
+ * Add ZSS support
 
 Stock Additions v0.1 (0.7.7)
 ===

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -81,7 +81,7 @@ class opParams:
                         'enable_long_derivative': Param(False, bool, 'If you have longitudinal overshooting, enable this! This enables derivative-based\n'
                                                                      'integral wind-down to help reduce overshooting within the long PID loop'),
                         'disengage_on_gas': Param(True, bool, 'Whether you want openpilot to disengage on gas input or not'),
-                        'no_ota_updates': Param(False, bool, 'Set this to True to disable all automatic updates. Reboot to take effect'),
+                        'auto_update': Param(False, bool, 'Toggles whether your device will update and reboot automatically on this fork'),
                         'dynamic_gas': Param(True, bool, 'Whether to use dynamic gas if your car is supported'),
                         'hide_auto_df_alerts': Param(False, bool, 'Hides the alert that shows what profile the model has chosen'),
                         'log_auto_df': Param(False, bool, 'Logs dynamic follow data for auto-df'),

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -98,7 +98,7 @@ class opParams:
     self._backup_file = '/data/op_params_corrupt.json'
     self._last_read_time = sec_since_boot()
     self.read_frequency = 2.5  # max frequency to read with self.get(...) (sec)
-    self._to_delete = ['lane_hug_direction', 'lane_hug_angle_offset', 'prius_use_lqr']  # a list of params you want to delete (unused)
+    self._to_delete = ['lane_hug_direction', 'lane_hug_angle_offset', 'prius_use_lqr', 'no_ota_updates']  # a list of params you want to delete (unused)
     self._run_init()  # restores, reads, and updates params
 
   def _run_init(self):  # does first time initializing of default params

--- a/selfdrive/common/version.h
+++ b/selfdrive/common/version.h
@@ -1,1 +1,1 @@
-#define COMMA_VERSION "0.7.7 - Stock Additions v0.1.1"
+#define COMMA_VERSION "0.7.7 - SA v0.1.1"

--- a/selfdrive/common/version.h
+++ b/selfdrive/common/version.h
@@ -1,1 +1,1 @@
-#define COMMA_VERSION "SA v0.1.1 (0.7.7-release)"
+#define COMMA_VERSION "0.7.7 - Stock Additions v0.1.1"

--- a/selfdrive/common/version.h
+++ b/selfdrive/common/version.h
@@ -1,1 +1,1 @@
-#define COMMA_VERSION "0.7.7-release"
+#define COMMA_VERSION "SA v0.1.1 (0.7.7-release)"

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -99,7 +99,7 @@ class DynamicCameraOffset:
       self.l_prob, self.r_prob = probs
 
       dynamic_offset = self._get_camera_offset(v_ego, active, angle_steers)
-      self._send_state()  # for alerts, before speed check so alerts don't get stuck on
+      self._send_state()  # for al erts, before speed check so alerts don't get stuck on
       if dynamic_offset is not None:
         return self.camera_offset + dynamic_offset
 

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -99,7 +99,7 @@ class DynamicCameraOffset:
       self.l_prob, self.r_prob = probs
 
       dynamic_offset = self._get_camera_offset(v_ego, active, angle_steers)
-      self._send_state()  # for al erts, before speed check so alerts don't get stuck on
+      self._send_state()  # for alerts, before speed check so alerts don't get stuck on
       if dynamic_offset is not None:
         return self.camera_offset + dynamic_offset
 

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -103,7 +103,7 @@ class DynamicCameraOffset:
       if dynamic_offset is not None:
         return self.camera_offset + dynamic_offset
 
-      self.i = 0  # reset when not  active
+      self.i = 0  # reset when not active
     return self.camera_offset  # don't offset if no lane line in direction we're going to hug
 
   def _get_camera_offset(self, v_ego, active, angle_steers):

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -100,7 +100,7 @@ class DynamicCameraOffset:
 
       dynamic_offset = self._get_camera_offset(v_ego, active, angle_steers)
       self._send_state()  # for alerts, before speed check so alerts don't get stuck on
-      if dynamic_offset is not None:
+      if dynamic_offset is not None:  # test
         return self.camera_offset + dynamic_offset
 
       self.i = 0  # reset when not active

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -100,7 +100,7 @@ class DynamicCameraOffset:
 
       dynamic_offset = self._get_camera_offset(v_ego, active, angle_steers)
       self._send_state()  # for alerts, before speed check so alerts don't get stuck on
-      if dynamic_offset is not None:  # test
+      if dynamic_offset is not None:
         return self.camera_offset + dynamic_offset
 
       self.i = 0  # reset when not active

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -103,7 +103,7 @@ class DynamicCameraOffset:
       if dynamic_offset is not None:
         return self.camera_offset + dynamic_offset
 
-      self.i = 0  # reset when not active
+      self.i = 0  # reset when not  active
     return self.camera_offset  # don't offset if no lane line in direction we're going to hug
 
   def _get_camera_offset(self, v_ego, active, angle_steers):

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -12,7 +12,6 @@ import textwrap
 from typing import Dict, List
 from selfdrive.swaglog import cloudlog, add_logentries_handler
 
-
 from common.basedir import BASEDIR, PARAMS
 from common.android import ANDROID
 WEBCAM = os.getenv("WEBCAM") is not None
@@ -21,7 +20,6 @@ os.environ['BASEDIR'] = BASEDIR
 
 TOTAL_SCONS_NODES = 1020
 prebuilt = os.path.exists(os.path.join(BASEDIR, 'prebuilt'))
-
 
 # Create folders needed for msgq
 try:
@@ -229,8 +227,8 @@ if ANDROID:
   persistent_processes += [
     'logcatd',
     'tombstoned',
-    'deleter',
     'updated'
+    'deleter',
   ]
 
 car_started_processes = [

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -11,7 +11,6 @@ import datetime
 import textwrap
 from typing import Dict, List
 from selfdrive.swaglog import cloudlog, add_logentries_handler
-from common.op_params import opParams
 
 
 from common.basedir import BASEDIR, PARAMS
@@ -23,8 +22,6 @@ os.environ['BASEDIR'] = BASEDIR
 TOTAL_SCONS_NODES = 1020
 prebuilt = os.path.exists(os.path.join(BASEDIR, 'prebuilt'))
 
-op_params = opParams()
-no_ota_updates = op_params.get('no_ota_updates') or os.path.exists('/data/no_ota_updates')
 
 # Create folders needed for msgq
 try:
@@ -233,9 +230,8 @@ if ANDROID:
     'logcatd',
     'tombstoned',
     'deleter',
+    'updated'
   ]
-if not no_ota_updates:
-  persistent_processes.append('updated')
 
 car_started_processes = [
   'controlsd',

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -227,7 +227,7 @@ if ANDROID:
   persistent_processes += [
     'logcatd',
     'tombstoned',
-    'updated'
+    'updated',
     'deleter',
   ]
 

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -12,6 +12,7 @@ import textwrap
 from typing import Dict, List
 from selfdrive.swaglog import cloudlog, add_logentries_handler
 
+
 from common.basedir import BASEDIR, PARAMS
 from common.android import ANDROID
 WEBCAM = os.getenv("WEBCAM") is not None

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -271,7 +271,7 @@ def finalize_from_ovfs_copy():
   cloudlog.info("done finalizing overlay")
 
 
-def attempt_update(time_offroad, need_reboot):
+def attempt_update():
   cloudlog.info("attempting git update inside staging overlay")
 
   setup_git_options(OVERLAY_MERGED)
@@ -314,24 +314,24 @@ def attempt_update(time_offroad, need_reboot):
     cloudlog.info("nothing new from git at this time")
 
   set_update_available_params(new_version=new_version)
-  return auto_update_reboot(time_offroad, need_reboot, new_version)
+  # return auto_update_reboot(time_offroad, need_reboot, new_version)
 
 
-def auto_update_reboot(time_offroad, need_reboot, new_version):
-  min_reboot_time = 5. * 60
-  if new_version:
-    need_reboot = True
-
-  if need_reboot:
-    if sec_since_boot() - time_offroad > min_reboot_time:
-      cloudlog.info(COLORS.RED + "AUTO UPDATE: REBOOTING" + COLORS.ENDC)
-      with open('/data/reboot_events.txt', 'a') as f:
-        f.write('{}: Auto update triggered reboot\n'.format(datetime.datetime.now()))
-      run(["am", "start", "-a", "android.intent.action.REBOOT"])
-    else:
-      cloudlog.info(COLORS.BLUE_GREEN + "UPDATE FOUND, waiting {} sec. until reboot".format(min_reboot_time - (sec_since_boot() - time_offroad)) + COLORS.ENDC)
-
-  return need_reboot
+# def auto_update_reboot(time_offroad, need_reboot, new_version):
+#   min_reboot_time = 5. * 60
+#   if new_version:
+#     need_reboot = True
+#
+#   if need_reboot:
+#     if sec_since_boot() - time_offroad > min_reboot_time:
+#       cloudlog.info(COLORS.RED + "AUTO UPDATE: REBOOTING" + COLORS.ENDC)
+#       with open('/data/reboot_events.txt', 'a') as f:
+#         f.write('{}: Auto update triggered reboot\n'.format(datetime.datetime.now()))
+#       run(["am", "start", "-a", "android.intent.action.REBOOT"])
+#     else:
+#       cloudlog.info(COLORS.BLUE_GREEN + "UPDATE FOUND, waiting {} sec. until reboot".format(min_reboot_time - (sec_since_boot() - time_offroad)) + COLORS.ENDC)
+#
+#   return need_reboot
 
 
 def main():
@@ -361,8 +361,6 @@ def main():
   time.sleep(30)
   wait_helper = WaitTimeHelper()
 
-  time_offroad = 0
-  need_reboot = False
   while True:
     update_failed_count += 1
     time_wrong = datetime.datetime.utcnow().year < 2019
@@ -387,11 +385,8 @@ def main():
           overlay_init_done = True
 
         if params.get("IsOffroad") == b"1":
-          need_reboot = attempt_update(time_offroad, need_reboot)
+          attempt_update()
           update_failed_count = 0
-        else:
-          time_offroad = sec_since_boot()
-          cloudlog.info("not running updater, openpilot running")
 
       except subprocess.CalledProcessError as e:
         cloudlog.event(

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -83,6 +83,7 @@ class WaitTimeHelper:
 
 def wait_between_updates(ready_event):
   ready_event.clear()
+  SHORT = True
   if SHORT:
     ready_event.wait(timeout=10)
   else:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -40,6 +40,7 @@ from common.colors import COLORS
 from common.params import Params
 from selfdrive.swaglog import cloudlog
 from common.realtime import sec_since_boot
+from common.op_params import opParams
 
 STAGING_ROOT = "/data/safe_staging"
 
@@ -56,6 +57,8 @@ ffi = FFI()
 ffi.cdef("int link(const char *oldpath, const char *newpath);")
 libc = ffi.dlopen(None)
 
+op_params = opParams()
+auto_update = op_params.get('auto_update') and not os.path.exists('/data/no_ota_updates')
 
 class WaitTimeHelper:
   ready_event = threading.Event()
@@ -318,6 +321,8 @@ def attempt_update(time_offroad, need_reboot):
 
 
 def auto_update_reboot(time_offroad, need_reboot, new_version):
+  if not auto_update:
+    return False
   min_reboot_time = 5. * 60
   if new_version:
     need_reboot = True

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -363,7 +363,7 @@ def main():
 
   # Wait a short time before our first update attempt
   # Avoids race with IsOffroad not being set, reduces manager startup load
-  time.sleep(30)
+  time.sleep(15)
   wait_helper = WaitTimeHelper()
 
   time_offroad = 0

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -123,7 +123,7 @@ def set_update_available_params(new_version=False):
 
   if new_version:
     try:
-      with open(os.path.join(FINALIZED, "RELEASES.md"), "rb") as f:
+      with open(os.path.join(FINALIZED, "SA_RELEASES.md"), "rb") as f:
         r = f.read()
       r = r[:r.find(b'\n\n')]  # Slice latest release notes
       params.put("ReleaseNotes", r + b"\n")

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -83,7 +83,6 @@ class WaitTimeHelper:
 
 def wait_between_updates(ready_event):
   ready_event.clear()
-  SHORT = True
   if SHORT:
     ready_event.wait(timeout=10)
   else:
@@ -324,11 +323,12 @@ def attempt_update(time_offroad, need_reboot):
 def auto_update_reboot(time_offroad, need_reboot, new_version):
   if not auto_update:
     return False
+
   min_reboot_time = 5. * 60
   if new_version:
     need_reboot = True
 
-  if need_reboot and op_params.get('auto_'):
+  if need_reboot:
     if sec_since_boot() - time_offroad > min_reboot_time:
       cloudlog.info(COLORS.RED + "AUTO UPDATE: REBOOTING" + COLORS.ENDC)
       with open('/data/reboot_events.txt', 'a') as f:

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -364,7 +364,7 @@ def main():
 
   # Wait a short time before our first update attempt
   # Avoids race with IsOffroad not being set, reduces manager startup load
-  time.sleep(15)
+  time.sleep(30)
   wait_helper = WaitTimeHelper()
 
   time_offroad = 0

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -271,7 +271,7 @@ def finalize_from_ovfs_copy():
   cloudlog.info("done finalizing overlay")
 
 
-def attempt_update():
+def attempt_update(time_offroad, need_reboot):
   cloudlog.info("attempting git update inside staging overlay")
 
   setup_git_options(OVERLAY_MERGED)
@@ -314,24 +314,24 @@ def attempt_update():
     cloudlog.info("nothing new from git at this time")
 
   set_update_available_params(new_version=new_version)
-  # return auto_update_reboot(time_offroad, need_reboot, new_version)
+  return auto_update_reboot(time_offroad, need_reboot, new_version)
 
 
-# def auto_update_reboot(time_offroad, need_reboot, new_version):
-#   min_reboot_time = 5. * 60
-#   if new_version:
-#     need_reboot = True
-#
-#   if need_reboot:
-#     if sec_since_boot() - time_offroad > min_reboot_time:
-#       cloudlog.info(COLORS.RED + "AUTO UPDATE: REBOOTING" + COLORS.ENDC)
-#       with open('/data/reboot_events.txt', 'a') as f:
-#         f.write('{}: Auto update triggered reboot\n'.format(datetime.datetime.now()))
-#       run(["am", "start", "-a", "android.intent.action.REBOOT"])
-#     else:
-#       cloudlog.info(COLORS.BLUE_GREEN + "UPDATE FOUND, waiting {} sec. until reboot".format(min_reboot_time - (sec_since_boot() - time_offroad)) + COLORS.ENDC)
-#
-#   return need_reboot
+def auto_update_reboot(time_offroad, need_reboot, new_version):
+  min_reboot_time = 5. * 60
+  if new_version:
+    need_reboot = True
+
+  if need_reboot and op_params.get('auto_'):
+    if sec_since_boot() - time_offroad > min_reboot_time:
+      cloudlog.info(COLORS.RED + "AUTO UPDATE: REBOOTING" + COLORS.ENDC)
+      with open('/data/reboot_events.txt', 'a') as f:
+        f.write('{}: Auto update triggered reboot\n'.format(datetime.datetime.now()))
+      run(["am", "start", "-a", "android.intent.action.REBOOT"])
+    else:
+      cloudlog.info(COLORS.BLUE_GREEN + "UPDATE FOUND, waiting {} sec. until reboot".format(min_reboot_time - (sec_since_boot() - time_offroad)) + COLORS.ENDC)
+
+  return need_reboot
 
 
 def main():
@@ -361,6 +361,8 @@ def main():
   time.sleep(30)
   wait_helper = WaitTimeHelper()
 
+  time_offroad = 0
+  need_reboot = False
   while True:
     update_failed_count += 1
     time_wrong = datetime.datetime.utcnow().year < 2019
@@ -385,8 +387,11 @@ def main():
           overlay_init_done = True
 
         if params.get("IsOffroad") == b"1":
-          attempt_update()
+          need_reboot = attempt_update(time_offroad, need_reboot)
           update_failed_count = 0
+        else:
+          time_offroad = sec_since_boot()
+          cloudlog.info("not running updater, openpilot running")
 
       except subprocess.CalledProcessError as e:
         cloudlog.event(


### PR DESCRIPTION
You can still turn the `auto_update` opParam back on to get the old functionality if you don't care what's new