### PR TITLE
Smoothly move back to center - dynamic camera offset

### DIFF
--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -124,7 +124,7 @@ class CarInterface(CarInterfaceBase):
       else:
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2 * 1.5], [0.05 * 1.5]]
         ret.lateralTuning.pid.kdBP = [0.]
-        ret.lateralTuning.pid.kdV = [0.9]
+        ret.lateralTuning.pid.kdV = [1.6]
         ret.lateralTuning.pid.kf = 0.0000325   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -122,9 +122,9 @@ class CarInterface(CarInterfaceBase):
         ret.lateralTuning.lqr.l = [0.3233671, 0.3185757]
         ret.lateralTuning.lqr.dcGain = 0.002237852961363602
       else:
-        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2 * 1.5], [0.05 * 1.5]]
+        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.22], [0.04125]]
         ret.lateralTuning.pid.kdBP = [0.]
-        ret.lateralTuning.pid.kdV = [0.9]
+        ret.lateralTuning.pid.kdV = [0.78]
         ret.lateralTuning.pid.kf = 0.0000325   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -122,9 +122,9 @@ class CarInterface(CarInterfaceBase):
         ret.lateralTuning.lqr.l = [0.3233671, 0.3185757]
         ret.lateralTuning.lqr.dcGain = 0.002237852961363602
       else:
-        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.22], [0.04125]]
+        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2 * 1.5], [0.05 * 1.5]]
         ret.lateralTuning.pid.kdBP = [0.]
-        ret.lateralTuning.pid.kdV = [0.78]
+        ret.lateralTuning.pid.kdV = [0.9]
         ret.lateralTuning.pid.kf = 0.0000325   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -124,7 +124,7 @@ class CarInterface(CarInterfaceBase):
       else:
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2 * 1.5], [0.05 * 1.5]]
         ret.lateralTuning.pid.kdBP = [0.]
-        ret.lateralTuning.pid.kdV = [1.6]
+        ret.lateralTuning.pid.kdV = [0.9]
         ret.lateralTuning.pid.kf = 0.0000325   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -90,7 +90,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
 
   def update(self, v_ego, active, angle_steers, lane_width_estimate, lane_width_certainty, polys, probs):
     self.camera_offset = self.op_params.get('camera_offset')  # update base offset from user
-    if self._enabled:
+    if self._enabled:  # if feature enabled
       self.sm.update(0)
       self.left_lane_oncoming = self.sm['laneSpeed'].leftLaneOncoming
       self.right_lane_oncoming = self.sm['laneSpeed'].rightLaneOncoming
@@ -130,7 +130,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
       self.last_right_lane_oncoming = self.right_lane_oncoming
     elif time_since_oncoming > self._ramp_down_times[-1]:  # return if it's x+ seconds after last oncoming, no need to offset
       return
-    else:  # no oncoming and not yet 2 seconds after we lost an oncoming lane. use last oncoming lane for 2 seconds to ramp down offset
+    else:  # no oncoming and not yet x seconds after we lost an oncoming lane. use last oncoming lane until we complete full offset time
       left_lane_oncoming = self.last_left_lane_oncoming
       right_lane_oncoming = self.last_right_lane_oncoming
 
@@ -150,9 +150,8 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
     self.i += error * self._k_i  # PI controller
     offset = self.i + error * self._k_p
 
-    if time_since_oncoming <= self._ramp_down_times[-1] and not self.have_oncoming:  # not yet 3 seconds after last oncoming, ramp down from 1.5 second
-      offset *= interp(time_since_oncoming, self._ramp_down_times, self._ramp_down_multipliers)  # ramp down offset
-
+    if time_since_oncoming <= self._ramp_down_times[-1] and not self.have_oncoming:
+      offset *= interp(time_since_oncoming, self._ramp_down_times, self._ramp_down_multipliers)  # we have passed initial full offset time, start to ramp down
     return offset
 
   def _send_state(self):

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -69,7 +69,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
     self._enabled = self.op_params.get('dynamic_camera_offset')
     self._min_enable_speed = 35 * CV.MPH_TO_MS
     self._min_lane_width_certainty = 0.4
-    hug = 0.1  # how much to hug
+    hug = 0.115  # how much to hug
     self._center_ratio = 0.5
     self._hug_left_ratio = self._center_ratio - hug
     self._hug_right_ratio = self._center_ratio + hug
@@ -78,8 +78,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
     self._ramp_angles = [0, 12.5, 25]
     self._ramp_angle_mods = [1, 0.85, 0.1]  # multiply offset by this based on angle
 
-    self._ramp_down_times = [self._keep_offset_for, self._keep_offset_for * 1.5]
-    self._ramp_down_multipliers = [1, 0]  # ramp down 1.5s after time has passed
+    self._ramp_down_times = [self._keep_offset_for, self._keep_offset_for * 1.25]
 
     self._poly_prob_speeds = [0, 25 * CV.MPH_TO_MS, 35 * CV.MPH_TO_MS, 60 * CV.MPH_TO_MS]
     self._poly_probs = [0.2, 0.25, 0.45, 0.55]  # we're good if only one line is above this
@@ -151,7 +150,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
     offset = self.i + error * self._k_p
 
     if time_since_oncoming <= self._ramp_down_times[-1] and not self.have_oncoming:
-      offset *= interp(time_since_oncoming, self._ramp_down_times, self._ramp_down_multipliers)  # we have passed initial full offset time, start to ramp down
+      offset = interp(time_since_oncoming, self._ramp_down_times, [offset, 0])  # we have passed initial full offset time, start to ramp down
     return offset
 
   def _send_state(self):

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -78,7 +78,7 @@ class DynamicCameraOffset:  # keeps away from oncoming traffic
     self._ramp_angles = [0, 12.5, 25]
     self._ramp_angle_mods = [1, 0.85, 0.1]  # multiply offset by this based on angle
 
-    self._ramp_down_times = [self._keep_offset_for, self._keep_offset_for * 1.25]
+    self._ramp_down_times = [self._keep_offset_for, self._keep_offset_for * 1.3]
 
     self._poly_prob_speeds = [0, 25 * CV.MPH_TO_MS, 35 * CV.MPH_TO_MS, 60 * CV.MPH_TO_MS]
     self._poly_probs = [0.2, 0.25, 0.45, 0.55]  # we're good if only one line is above this


### PR DESCRIPTION
Should have been checking for the full time + the offset I use in `self._ramp_down_times`, but I was only checking if time is less than the initial full offset time