### PR TITLE
Disable path coloring when not engaged, slight startup speed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stock Additions v0.5.3 (0.7.7)
+# Stock Additions v0.5.4 (0.7.7)
 
 Stock Additions is a fork of openpilot designed to be minimal in design while boasting various feature additions and behavior improvements over stock. I have a 2017 Toyota Corolla with comma pedal, so most of my changes are designed to improve the longitudinal performance.
 

--- a/SA_RELEASES.md
+++ b/SA_RELEASES.md
@@ -1,3 +1,8 @@
+Stock Additions v0.5.4 - 2020-10-15 (0.7.7)
+===
+ * Make model path default grey when not engaged, only color when engaged
+ * About 1.6 seconds faster starting up (from a recent commit from stock)
+
 Stock Additions v0.5.3 - 2020-9-15 (0.7.7)
 ===
  * Properly set unsafe_mode in boardd. This might fix panda flashing issues for new users, since it won't be required

--- a/SConstruct
+++ b/SConstruct
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import platform
 
+Decider('MD5-timestamp')
 AddOption('--test',
           action='store_true',
           help='build test files')

--- a/common/apk.py
+++ b/common/apk.py
@@ -31,9 +31,16 @@ def start_offroad():
   system("am start -n ai.comma.plus.offroad/.MainActivity")
 
 def set_package_permissions():
-  pm_grant("ai.comma.plus.offroad", "android.permission.ACCESS_FINE_LOCATION")
-  pm_grant("ai.comma.plus.offroad", "android.permission.READ_PHONE_STATE")
-  pm_grant("ai.comma.plus.offroad", "android.permission.READ_EXTERNAL_STORAGE")
+  try:
+    output = subprocess.check_output(['dumpsys', 'package', 'ai.comma.plus.offroad'], encoding="utf-8")
+    given_permissions = output.split("runtime permissions")[1]
+  except Exception:
+    given_permissions = ""
+
+  wanted_permissions = ["ACCESS_FINE_LOCATION", "READ_PHONE_STATE", "READ_EXTERNAL_STORAGE"]
+  for permission in wanted_permissions:
+    if permission not in given_permissions:
+      pm_grant("ai.comma.plus.offroad", "android.permission." + permission)
   appops_set("ai.comma.plus.offroad", "SU", "allow")
   appops_set("ai.comma.plus.offroad", "WIFI_SCAN", "allow")
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -266,7 +266,7 @@ class Controls:
     # alert priority is defined by code location, keeping is highest, then lane speed alert, then auto-df alert
     if self.sm_smiskol['modelLongButton'].enabled != self.last_model_long:
       extra_text_1 = 'disabled!' if self.last_model_long else 'enabled!'
-      extra_text_2 = '' if self.last_model_long else ', model may slow unexpectedly'
+      extra_text_2 = '' if self.last_model_long else ', model may behave unexpectedly'
       self.AM.SA_add('modelLongAlert', extra_text_1=extra_text_1, extra_text_2=extra_text_2)
       return
 

--- a/selfdrive/ui/paint.cc
+++ b/selfdrive/ui/paint.cc
@@ -205,7 +205,7 @@ static void update_all_track_data(UIState *s) {
 }
 
 
-static void ui_draw_track(UIState *s, bool is_mpc, track_vertices_data *pvd, const float *p_poly) {
+static void ui_draw_track(UIState *s, bool is_enabled, track_vertices_data *pvd, const float *p_poly) {
  if (pvd->cnt == 0) return;
 
   nvgBeginPath(s->vg);
@@ -219,15 +219,14 @@ static void ui_draw_track(UIState *s, bool is_mpc, track_vertices_data *pvd, con
   float dist = 1.8 * fmax(s->scene.controls_state.getVEgo(), 4.4704);  // eval car position at 1.8s from path (min 10 mph)
   float lat_pos = std::abs((p_poly[0] * pow(dist, 3)) + (p_poly[1] * pow(dist, 2)) + (p_poly[2] * dist));  // don't include path offset
   float hue = lat_pos * -39.46 + 148;  // interp from {0, 4.5} -> {148, 0}
-  if (is_mpc) {
-    // Draw colored MPC track
-    const uint8_t *clr = bg_colors[s->status];
-    track_bg = nvgLinearGradient(s->vg, vwp_w, vwp_h, vwp_w, vwp_h*.4,
-      nvgRGBA(clr[0], clr[1], clr[2], 255), nvgRGBA(clr[0], clr[1], clr[2], 255/2));
-  } else {
+  if (is_enabled) {
     // Draw colored vision track
     track_bg = nvgLinearGradient(s->vg, vwp_w, vwp_h*.9, vwp_w, vwp_h*.4,
       nvgHSLA(hue / 360., .94, .51, 255), nvgHSLA(hue / 360., .73, .49, 100));
+  } else {
+    // Draw white vision track
+    track_bg = nvgLinearGradient(s->vg, vwp_w, vwp_h, vwp_w, vwp_h*.4,
+      COLOR_WHITE, COLOR_WHITE_ALPHA(0));
   }
   nvgFillPaint(s->vg, track_bg);
   nvgFill(s->vg);
@@ -346,10 +345,7 @@ static void ui_draw_vision_lanes(UIState *s) {
   // Draw vision path
   const float *p_poly = scene->model.path.poly;
   ui_draw_track(s, false, &s->track_vertices[0], p_poly);
-  if (scene->controls_state.getEnabled()) {
-    // Draw MPC path when engaged
-    ui_draw_track(s, true, &s->track_vertices[1], p_poly);
-  }
+  ui_draw_track(s, scene->controls_state.getEnabled(), &s->track_vertices[0], p_poly);
 }
 
 // Draw all world space objects.


### PR DESCRIPTION
- Make model path default grey when not engaged, only color when engaged
- About 1.6 seconds faster starting up (from a recent commit from stock 8a952cec33f2d4641f9d8a2f7f919204a9f03f26)