### PR TITLE
Torque unification project testing

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -41,6 +41,10 @@ class CarInterfaceBase():
     return 1.
 
   @staticmethod
+  def compute_torque(torque, speed):  # no behavior change for cars without custom fit torque function
+    return float(torque)
+
+  @staticmethod
   def compute_gb(accel, speed):
     raise NotImplementedError
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -107,7 +107,7 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.444  # not optimized yet
       ret.mass = 2860. * CV.LB_TO_KG + STD_CARGO_KG  # mean between normal and hybrid
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
-      ret.lateralTuning.pid.kf = 0.00003   # full torque for 20 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00003 * 1.833   # full torque for 20 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.LEXUS_RX:
       stop_and_go = True

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -11,6 +11,18 @@ EventName = car.CarEvent.EventName
 
 class CarInterface(CarInterfaceBase):
   @staticmethod
+  def compute_torque(torque, speed):
+    def std_feedforward(_angle, _speed):
+      return _speed ** 2 * _angle
+
+    def acc_feedforward(_angle, _speed):
+      _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
+      return (_c1 * _speed ** 2 + _c2 * _speed + _c3) * _angle
+
+    mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
+    return float(torque) * mult
+
+  @staticmethod
   def compute_gb(accel, speed):
     return float(accel) / CarControllerParams.ACCEL_SCALE
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -19,6 +19,7 @@ class CarInterface(CarInterfaceBase):
       _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
       return (_c1 * _speed ** 2 + _c2 * _speed + _c3) * _angle
 
+    speed = max(speed, 5 * CV.MPH_TO_MS)  # avoids zero div and too high of multipliers
     mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
     return float(torque) * mult
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -111,7 +111,7 @@ class Controls:
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP)
     elif self.CP.lateralTuning.which() == 'pid':
-      self.LaC = LatControlPID(self.CP)
+      self.LaC = LatControlPID(self.CP, self.CI.compute_torque)
     elif self.CP.lateralTuning.which() == 'indi':
       self.LaC = LatControlINDI(self.CP)
     elif self.CP.lateralTuning.which() == 'lqr':

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -108,6 +108,7 @@ class Controls:
     self.LoC = LongControl(self.CP, self.CI.compute_gb)
     self.VM = VehicleModel(self.CP)
 
+    # todo: implement convert for other controllers (make sure to convert before clip)
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:
       self.LaC = LatControlAngle(self.CP)
     elif self.CP.lateralTuning.which() == 'pid':

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -6,11 +6,11 @@ from cereal import log
 
 
 class LatControlPID():
-  def __init__(self, CP):
+  def __init__(self, CP, compute_torque):
     self.pid = PIController((CP.lateralTuning.pid.kpBP, CP.lateralTuning.pid.kpV),
                             (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
                             k_f=CP.lateralTuning.pid.kf, pos_limit=1.0, neg_limit=-1.0,
-                            sat_limit=CP.steerLimitTimer)
+                            sat_limit=CP.steerLimitTimer, convert=compute_torque)
 
   def reset(self):
     self.pid.reset()

--- a/selfdrive/debug/torque-unification.py
+++ b/selfdrive/debug/torque-unification.py
@@ -1,0 +1,53 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from selfdrive.config import Conversions as CV
+
+
+def std_feedforward(angle, speed, mph=False):
+  """
+  What latcontrol_pid uses and is technically correct (~lateral accel)
+  """
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  return speed ** 2 * angle
+
+
+def acc_feedforward(angle, speed, mph=False):
+  """
+  Fitted from data from 2017 Corolla. Much more accurate at low speeds
+  (Torque almost drops to 0 at low speeds with std feedforward)
+  """
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  # todo: this is a bit out of date, it was fitted assuming 0.12s of delay
+  _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
+  return (_c1 * speed ** 2 + _c2 * speed + _c3) * angle
+
+
+def convert_torque_corolla(speed, mph=False):
+  """Returns a multiplier to convert universal torque to vehicle-specific torque"""
+  # todo: can we fit a function that outputs this without calculating both feedforwards?
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
+  return mult
+
+
+# Plot how multiplier changes with speed
+spds = np.linspace(10, 70, 61)
+mults = convert_torque_corolla(spds, mph=True)
+plt.title('output of torque conversion function')
+plt.plot(spds, mults, label='torque multiplier')
+plt.xlabel('speed (mph)')
+plt.legend()
+
+
+# Plot comparison between std ff and more accurate fitted ff
+plt.figure()
+deg = 10
+plt.title(f'torque response at {deg} degrees')
+torques = std_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='standard feedforward (~lateral accel)')
+
+torques = acc_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='custom-fit \'17 Corolla feedforward')
+plt.xlabel('speed (mph)')
+plt.ylabel('torque')
+plt.legend()

--- a/selfdrive/debug/torque-unification.py
+++ b/selfdrive/debug/torque-unification.py
@@ -1,66 +1,52 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import time
 from selfdrive.config import Conversions as CV
-from scipy.optimize import curve_fit
 
 
-def std_feedforward(angle, speed):
+def std_feedforward(angle, speed, mph=False):
   """
   What latcontrol_pid uses and is technically correct (~lateral accel)
   """
+  speed = CV.MPH_TO_MS * speed if mph else speed
   return speed ** 2 * angle
 
 
-def acc_feedforward(angle, speed):
+def acc_feedforward(angle, speed, mph=False):
   """
   Fitted from data from 2017 Corolla. Much more accurate at low speeds
   (Torque almost drops to 0 at low speeds with std feedforward)
   """
+  speed = CV.MPH_TO_MS * speed if mph else speed
   # todo: this is a bit out of date, it was fitted assuming 0.12s of delay
   _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
   return (_c1 * speed ** 2 + _c2 * speed + _c3) * angle
 
 
-def convert_torque_corolla(speed):
+def convert_torque_corolla(speed, mph=False):
   """Returns a multiplier to convert universal torque to vehicle-specific torque"""
   # todo: can we fit a function that outputs this without calculating both feedforwards?
-  speed = np.array([max(s, 5 * CV.MPH_TO_MS) for s in speed])
+  speed = CV.MPH_TO_MS * speed if mph else speed
   mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
   return mult
 
 
-fitting = True
-def convert_torque_corolla_fitted(speed, _c1, _c2, _c3):
-  # this is almost 1 to 1 with above and only ~0.001 seconds slower after 1 hour
-  # edit: it can either be accurate from 1-5 mph or 5-70 mph, not really both
-  # but if we clip it below x (5?) mph then it doesn't really matter
-  if not fitting:
-    speed = [max(s, 5 * CV.MPH_TO_MS) for s in speed]
-  return np.exp(_c2 * -(np.log(speed) - _c1)) + _c3
+def convert_torque_corolla_new(speed, mph=False):
+  """Returns a multiplier to convert universal torque to vehicle-specific torque"""
+  # todo: can we fit a function that outputs this without calculating both feedforwards?
+  speed = CV.MPH_TO_MS * speed if mph else speed
+  weight = np.interp(speed, [0, 20 * CV.MPH_TO_MS], [0.5, 0])
+  speed = speed * (1 - weight) + 20 * CV.MPH_TO_MS * weight
+  mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
+  return mult
 
 
 # Plot how multiplier changes with speed
-spds = np.linspace(1, 70, 6000*60) * CV.MPH_TO_MS  # *60 is 1 hour
-t = time.time()
-mults = convert_torque_corolla(spds)
-t = time.time() - t
-print(f'Took {t} seconds to execute using ff functions')
-
-params = curve_fit(convert_torque_corolla_fitted, spds, mults)[0].tolist()
-# params = [2.264884864988784, 1.9174723981343285, 0.7601190196820092]  # 1-70 mph
-# params = [2.4175284500713237, 1.7501977566285476, 0.5355805302921479]  # 5-70 mph
-print(f'Params: {params}')
-fitting = False
-
-t = time.time()
-mults_fitted = convert_torque_corolla_fitted(spds, *params)
-t = time.time() - t
-print(f'Took {t} seconds to execute fitted function')
-
+spds = np.linspace(0.01, 70, 1000)
+mults = convert_torque_corolla(spds, mph=True)
+mults_new = [convert_torque_corolla_new(spd, mph=True) for spd in spds]
 plt.title('output of torque conversion function')
-plt.plot(spds * CV.MS_TO_MPH, mults, label='torque multiplier')
-# plt.plot(spds * CV.MS_TO_MPH, mults_fitted, label='torque multiplier (fitted)')
+# plt.plot(spds, mults, label='torque multiplier')
+plt.plot(spds, mults_new, label='new torque multiplier')
 plt.xlabel('speed (mph)')
 plt.legend()
 
@@ -69,14 +55,17 @@ plt.legend()
 plt.figure()
 deg = 10
 plt.title(f'torque response at {deg} degrees')
-torques = std_feedforward(deg, spds)
-plt.plot(spds * CV.MS_TO_MPH, torques, label='standard feedforward (~lateral accel)')
+torques = std_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='standard feedforward (~lateral accel)')
 
-torques = std_feedforward(deg, spds) * convert_torque_corolla(spds)
-plt.plot(spds * CV.MS_TO_MPH, torques, label='standard feedforward converted')
+torques = acc_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques, label='custom-fit \'17 Corolla feedforward')
 
-torques = acc_feedforward(deg, spds)
-plt.plot(spds * CV.MS_TO_MPH, torques, label='custom-fit \'17 Corolla feedforward')
+torques = std_feedforward(deg, spds, mph=True)
+plt.plot(spds, torques * mults, label='standard ff transformed')
+
+plt.plot(spds, torques * mults_new, label='standard ff transformed new')
+
 plt.xlabel('speed (mph)')
 plt.ylabel('torque')
 plt.legend()

--- a/selfdrive/debug/torque-unification.py
+++ b/selfdrive/debug/torque-unification.py
@@ -25,6 +25,7 @@ def acc_feedforward(angle, speed):
 def convert_torque_corolla(speed):
   """Returns a multiplier to convert universal torque to vehicle-specific torque"""
   # todo: can we fit a function that outputs this without calculating both feedforwards?
+  speed = np.array([max(s, 5 * CV.MPH_TO_MS) for s in speed])
   mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
   return mult
 

--- a/selfdrive/debug/torque-unification.py
+++ b/selfdrive/debug/torque-unification.py
@@ -1,40 +1,65 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import time
 from selfdrive.config import Conversions as CV
+from scipy.optimize import curve_fit
 
 
-def std_feedforward(angle, speed, mph=False):
+def std_feedforward(angle, speed):
   """
   What latcontrol_pid uses and is technically correct (~lateral accel)
   """
-  speed = CV.MPH_TO_MS * speed if mph else speed
   return speed ** 2 * angle
 
 
-def acc_feedforward(angle, speed, mph=False):
+def acc_feedforward(angle, speed):
   """
   Fitted from data from 2017 Corolla. Much more accurate at low speeds
   (Torque almost drops to 0 at low speeds with std feedforward)
   """
-  speed = CV.MPH_TO_MS * speed if mph else speed
   # todo: this is a bit out of date, it was fitted assuming 0.12s of delay
   _c1, _c2, _c3 = 0.35189607550172824, 7.506201251644202, 69.226826411091
   return (_c1 * speed ** 2 + _c2 * speed + _c3) * angle
 
 
-def convert_torque_corolla(speed, mph=False):
+def convert_torque_corolla(speed):
   """Returns a multiplier to convert universal torque to vehicle-specific torque"""
   # todo: can we fit a function that outputs this without calculating both feedforwards?
-  speed = CV.MPH_TO_MS * speed if mph else speed
   mult = acc_feedforward(1, speed) / std_feedforward(1, speed)
   return mult
 
 
+fitting = True
+def convert_torque_corolla_fitted(speed, _c1, _c2, _c3):
+  # this is almost 1 to 1 with above and only ~0.001 seconds slower after 1 hour
+  # edit: it can either be accurate from 1-5 mph or 5-70 mph, not really both
+  # but if we clip it below x (5?) mph then it doesn't really matter
+  if not fitting:
+    speed = [max(s, 5 * CV.MPH_TO_MS) for s in speed]
+  return np.exp(_c2 * -(np.log(speed) - _c1)) + _c3
+
+
 # Plot how multiplier changes with speed
-spds = np.linspace(10, 70, 61)
-mults = convert_torque_corolla(spds, mph=True)
+spds = np.linspace(1, 70, 6000*60) * CV.MPH_TO_MS  # *60 is 1 hour
+t = time.time()
+mults = convert_torque_corolla(spds)
+t = time.time() - t
+print(f'Took {t} seconds to execute using ff functions')
+
+params = curve_fit(convert_torque_corolla_fitted, spds, mults)[0].tolist()
+# params = [2.264884864988784, 1.9174723981343285, 0.7601190196820092]  # 1-70 mph
+# params = [2.4175284500713237, 1.7501977566285476, 0.5355805302921479]  # 5-70 mph
+print(f'Params: {params}')
+fitting = False
+
+t = time.time()
+mults_fitted = convert_torque_corolla_fitted(spds, *params)
+t = time.time() - t
+print(f'Took {t} seconds to execute fitted function')
+
 plt.title('output of torque conversion function')
-plt.plot(spds, mults, label='torque multiplier')
+plt.plot(spds * CV.MS_TO_MPH, mults, label='torque multiplier')
+plt.plot(spds * CV.MS_TO_MPH, mults_fitted, label='torque multiplier (fitted)')
 plt.xlabel('speed (mph)')
 plt.legend()
 
@@ -43,11 +68,11 @@ plt.legend()
 plt.figure()
 deg = 10
 plt.title(f'torque response at {deg} degrees')
-torques = std_feedforward(deg, spds, mph=True)
-plt.plot(spds, torques, label='standard feedforward (~lateral accel)')
+torques = std_feedforward(deg, spds)
+plt.plot(spds * CV.MS_TO_MPH, torques, label='standard feedforward (~lateral accel)')
 
-torques = acc_feedforward(deg, spds, mph=True)
-plt.plot(spds, torques, label='custom-fit \'17 Corolla feedforward')
+torques = acc_feedforward(deg, spds)
+plt.plot(spds * CV.MS_TO_MPH, torques, label='custom-fit \'17 Corolla feedforward')
 plt.xlabel('speed (mph)')
 plt.ylabel('torque')
 plt.legend()

--- a/selfdrive/debug/torque-unification.py
+++ b/selfdrive/debug/torque-unification.py
@@ -60,7 +60,7 @@ print(f'Took {t} seconds to execute fitted function')
 
 plt.title('output of torque conversion function')
 plt.plot(spds * CV.MS_TO_MPH, mults, label='torque multiplier')
-plt.plot(spds * CV.MS_TO_MPH, mults_fitted, label='torque multiplier (fitted)')
+# plt.plot(spds * CV.MS_TO_MPH, mults_fitted, label='torque multiplier (fitted)')
 plt.xlabel('speed (mph)')
 plt.legend()
 
@@ -71,6 +71,9 @@ deg = 10
 plt.title(f'torque response at {deg} degrees')
 torques = std_feedforward(deg, spds)
 plt.plot(spds * CV.MS_TO_MPH, torques, label='standard feedforward (~lateral accel)')
+
+torques = std_feedforward(deg, spds) * convert_torque_corolla(spds)
+plt.plot(spds * CV.MS_TO_MPH, torques, label='standard feedforward converted')
 
 torques = acc_feedforward(deg, spds)
 plt.plot(spds * CV.MS_TO_MPH, torques, label='custom-fit \'17 Corolla feedforward')


### PR DESCRIPTION
Addresses geohot's idea here: https://github.com/commaai/openpilot/pull/2705

Previously we were only transforming feedforward for Toyota, but this will also transform proportional, integral, etc. which might give better results.

Todo:
- [ ] Fit an (*accurate*) ff function for many cars and implement
- [x] Fit an (*accurate*) ff function for '17 Corolla and implement
- [x] Implement in latcontrol_pid (uses pid's `convert` functionality)
- [ ] ~See what is needed to fit a function to output multiplier without calculating both standard ff and car-specific ff~
  - Edit: Calculating both standard ff and car-specific ff each frame usually is quicker than a fitted function, and more accurate
- [ ] Implement convert function in other latcontrollers (can't do in carcontroller or controlsd because it should be applied before range clipping. ie. we'd never be able to reach max torque when multiplier is under 1)